### PR TITLE
Act 630 decorate errors

### DIFF
--- a/_tests/integration/android_test.go
+++ b/_tests/integration/android_test.go
@@ -280,9 +280,15 @@ warnings_with_recommendations:
 
 var sampleAppsSDK22NoGradlewResultYML = `warnings:
   android: []
-errors:
+errors_with_recommendations:
   general:
-  - No known platform detected
+  - error: No known platform detected
+    recommendations:
+      DetailedError:
+        title: We couldn’t recognize your platform.
+        description: Our auto-configurator supports react-native, flutter, ionic,
+          cordova, ios, macos, android, xamarin, fastlane projects. If you’re adding
+          something else, skip this step and configure your Workflow manually.
 warnings_with_recommendations:
   android:
   - error: |-

--- a/_tests/integration/android_test.go
+++ b/_tests/integration/android_test.go
@@ -274,17 +274,28 @@ configs:
           - cache-push@%s: {}
 warnings:
   android: []
+warnings_with_recommendations:
+  android: []
 `, sampleAppsAndroidSDK22SubdirVersions...)
 
 var sampleAppsSDK22NoGradlewResultYML = `warnings:
-  android:
-  - |-
-    <b>No Gradle Wrapper (gradlew) found.</b>
-    Using a Gradle Wrapper (gradlew) is required, as the wrapper is what makes sure
-    that the right Gradle version is installed and used for the build. More info/guide: <a>https://docs.gradle.org/current/userguide/gradle_wrapper.html</a>
+  android: []
 errors:
   general:
   - No known platform detected
+warnings_with_recommendations:
+  android:
+  - error: |-
+      <b>No Gradle Wrapper (gradlew) found.</b>
+      Using a Gradle Wrapper (gradlew) is required, as the wrapper is what makes sure
+      that the right Gradle version is installed and used for the build. More info/guide: <a>https://docs.gradle.org/current/userguide/gradle_wrapper.html</a>
+    recommendations:
+      DetailedError:
+        title: We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew
+          file in your project’s root directory.
+        description: The Gradle Wrapper ensures that the right Gradle version is installed
+          and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the
+          Gradle Wrapper in the Gradle docs</a>.
 `
 
 var sampleAppsAndroid22Versions = []interface{}{
@@ -443,6 +454,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
 warnings:
+  android: []
+warnings_with_recommendations:
   android: []
 `, sampleAppsAndroid22Versions...)
 
@@ -603,6 +616,8 @@ configs:
           - cache-push@%s: {}
 warnings:
   android: []
+warnings_with_recommendations:
+  android: []
 `, androidNonExecutableGradlewVersions...)
 
 var sampleAppsKotlinDSLResultYML = fmt.Sprintf(`options:
@@ -736,5 +751,7 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
 warnings:
+  android: []
+warnings_with_recommendations:
   android: []
 `, sampleAppsAndroidSDK22SubdirVersions...)

--- a/_tests/integration/cordova_test.go
+++ b/_tests/integration/cordova_test.go
@@ -132,6 +132,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
 warnings:
   cordova: []
+warnings_with_recommendations:
+  cordova: []
 `, sampleAppsCordovaWithJasmineVersions...)
 
 var sampleAppsCordovaWithKarmaJasmineVersions = []interface{}{
@@ -212,5 +214,7 @@ configs:
           - karma-jasmine-runner@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
+  cordova: []
+warnings_with_recommendations:
   cordova: []
   `, sampleAppsCordovaWithKarmaJasmineVersions...)

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -202,4 +202,7 @@ configs:
 warnings:
   fastlane: []
   ios: []
+warnings_with_recommendations:
+  fastlane: []
+  ios: []
 `, fastlaneVersions...)

--- a/_tests/integration/flutter_test.go
+++ b/_tests/integration/flutter_test.go
@@ -703,6 +703,8 @@ configs:
           - cache-push@%s: {}
 warnings:
   flutter: []
+warnings_with_recommendations:
+  flutter: []
 `, flutterSampleAppVersions...)
 
 var flutterSamplePackageVersions = []interface{}{
@@ -1268,6 +1270,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
 warnings:
+  flutter: []
+warnings_with_recommendations:
   flutter: []
 `, flutterSamplePackageVersions...)
 
@@ -1902,5 +1906,7 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
 warnings:
+  flutter: []
+warnings_with_recommendations:
   flutter: []
 `, flutterSamplePluginVersions...)

--- a/_tests/integration/ionic_test.go
+++ b/_tests/integration/ionic_test.go
@@ -104,4 +104,6 @@ configs:
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ionic: []
+warnings_with_recommendations:
+  ionic: []
 `, ionic2Versions...)

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -201,11 +201,21 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
 warnings:
+  ios: []
+warnings_with_recommendations:
   ios:
-  - |-
-    No shared schemes found for project: BitriseXcode7Sample.xcodeproj.
-    Automatically generated schemes may differ from the ones in your project.
-    Make sure to <a href="http://devcenter.bitrise.io/ios/frequent-ios-issues/#xcode-scheme-not-found">share your schemes</a> for the expected behaviour.
+  - error: |-
+      No shared schemes found for project: BitriseXcode7Sample.xcodeproj.
+      Automatically generated schemes may differ from the ones in your project.
+      Make sure to <a href="http://devcenter.bitrise.io/ios/frequent-ios-issues/#xcode-scheme-not-found">share your schemes</a> for the expected behaviour.
+    recommendations:
+      DetailedError:
+        title: We couldn’t parse your project files.
+        description: |-
+          Our auto-configurator returned the following error:
+          No shared schemes found for project: BitriseXcode7Sample.xcodeproj.
+          Automatically generated schemes may differ from the ones in your project.
+          Make sure to <a href="http://devcenter.bitrise.io/ios/frequent-ios-issues/#xcode-scheme-not-found">share your schemes</a> for the expected behaviour.
 `, iosNoSharedSchemesVersions...)
 
 var iosCocoapodsAtRootVersions = []interface{}{
@@ -317,6 +327,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
 warnings:
+  ios: []
+warnings_with_recommendations:
   ios: []
 `, iosCocoapodsAtRootVersions...)
 
@@ -530,6 +542,8 @@ configs:
           - cache-push@%s: {}
 warnings:
   ios: []
+warnings_with_recommendations:
+  ios: []
 `, sampleAppsIosWatchkitVersions...)
 
 var sampleAppsCarthageVersions = []interface{}{
@@ -645,5 +659,7 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
 warnings:
+  ios: []
+warnings_with_recommendations:
   ios: []
 `, sampleAppsCarthageVersions...)

--- a/_tests/integration/mac_test.go
+++ b/_tests/integration/mac_test.go
@@ -144,4 +144,6 @@ configs:
           - cache-push@%s: {}
 warnings:
   macos: []
+warnings_with_recommendations:
+  macos: []
 `, sampleAppsOSX1011Versions...)

--- a/_tests/integration/reactnative_expo_test.go
+++ b/_tests/integration/reactnative_expo_test.go
@@ -295,6 +295,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
+warnings_with_recommendations:
+  react-native: []
 `, bitriseCRNAVersions...)
 
 var bitriseExpoKitVersions = []interface{}{
@@ -612,5 +614,7 @@ configs:
               - command: test
           - deploy-to-bitrise-io@%s: {}
 warnings:
+  react-native: []
+warnings_with_recommendations:
   react-native: []
 `, bitriseExpoKitVersions...)

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -260,6 +260,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
+warnings_with_recommendations:
+  react-native: []
 `, sampleAppsReactNativeSubdirVersions...)
 
 var sampleAppsReactNativeIosAndAndroidVersions = []interface{}{
@@ -441,6 +443,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
+warnings_with_recommendations:
+  react-native: []
 `, sampleAppsReactNativeIosAndAndroidVersions...)
 
 var sampleAppsReactNativeIosAndAndroidYarnVersions = []interface{}{
@@ -621,5 +625,7 @@ configs:
               - command: test
           - deploy-to-bitrise-io@%s: {}
 warnings:
+  react-native: []
+warnings_with_recommendations:
   react-native: []
 `, sampleAppsReactNativeIosAndAndroidYarnVersions...)

--- a/_tests/integration/xamarin_test.go
+++ b/_tests/integration/xamarin_test.go
@@ -153,6 +153,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
 warnings:
   xamarin: []
+warnings_with_recommendations:
+  xamarin: []
 `, xamarinSampleAppVersions...)
 
 var sampleAppsXamarinIosVersions = []interface{}{
@@ -233,6 +235,8 @@ configs:
           - deploy-to-bitrise-io@%s: {}
 warnings:
   xamarin: []
+warnings_with_recommendations:
+  xamarin: []
 `, sampleAppsXamarinIosVersions...)
 
 var sampleAppsXamarinAndroidVersions = []interface{}{
@@ -304,5 +308,7 @@ configs:
               - xamarin_platform: $BITRISE_XAMARIN_PLATFORM
           - deploy-to-bitrise-io@%s: {}
 warnings:
+  xamarin: []
+warnings_with_recommendations:
   xamarin: []
 `, sampleAppsXamarinAndroidVersions...)

--- a/errormapper/errormapper.go
+++ b/errormapper/errormapper.go
@@ -1,0 +1,68 @@
+package errormapper
+
+import (
+	"regexp"
+
+	"github.com/bitrise-io/bitrise-init/step"
+)
+
+const (
+	// UnknownParam ...
+	UnknownParam = "::unknown::"
+	// DetailedErrorRecKey ...
+	DetailedErrorRecKey = "DetailedError"
+)
+
+// DetailedError ...
+type DetailedError struct {
+	Title       string
+	Description string
+}
+
+// NewDetailedErrorRecommendation ...
+func NewDetailedErrorRecommendation(detailedError DetailedError) step.Recommendation {
+	return step.Recommendation{
+		DetailedErrorRecKey: detailedError,
+	}
+}
+
+// DetailedErrorBuilder ...
+type DetailedErrorBuilder = func(...string) DetailedError
+
+// GetParamAt ...
+func GetParamAt(index int, params []string) string {
+	res := UnknownParam
+	if index >= 0 && len(params) > index {
+		res = params[index]
+	}
+	return res
+}
+
+// PatternToDetailedErrorBuilder ...
+type PatternToDetailedErrorBuilder map[string]DetailedErrorBuilder
+
+// PatternErrorMatcher ...
+type PatternErrorMatcher struct {
+	DefaultBuilder   DetailedErrorBuilder
+	PatternToBuilder PatternToDetailedErrorBuilder
+}
+
+// Run ...
+func (m *PatternErrorMatcher) Run(msg string) step.Recommendation {
+	for pattern, builder := range m.PatternToBuilder {
+		re := regexp.MustCompile(pattern)
+		if re.MatchString(msg) {
+			// [search_string, match1, match2, ...]
+			matches := re.FindStringSubmatch(msg)
+			// Drop the first item, which is always the search_string itself
+			// [search_string] -> []
+			// [search_string, match1, ...] -> [match1, ...]
+			params := matches[1:]
+			detail := builder(params...)
+			return NewDetailedErrorRecommendation(detail)
+		}
+	}
+
+	detail := m.DefaultBuilder(msg)
+	return NewDetailedErrorRecommendation(detail)
+}

--- a/errormapper/errormapper_test.go
+++ b/errormapper/errormapper_test.go
@@ -1,0 +1,225 @@
+package errormapper
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/bitrise-io/bitrise-init/step"
+)
+
+func Test_newDetailedErrorRecommendation(t *testing.T) {
+	type args struct {
+		detailedError DetailedError
+	}
+	tests := []struct {
+		name string
+		args args
+		want step.Recommendation
+	}{
+		{
+			name: "newDetailedErrorRecommendation with nil",
+			args: args{
+				detailedError: DetailedError{
+					Title:       "TestTitle",
+					Description: "TestDesciption",
+				},
+			},
+			want: step.Recommendation{
+				DetailedErrorRecKey: DetailedError{
+					Title:       "TestTitle",
+					Description: "TestDesciption",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewDetailedErrorRecommendation(tt.args.detailedError); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newDetailedErrorRecommendation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getParamAt(t *testing.T) {
+	type args struct {
+		index  int
+		params []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "getParamsAt(0, nil)",
+			args: args{
+				index:  0,
+				params: nil,
+			},
+			want: UnknownParam,
+		},
+		{
+			name: "getParamsAt(0, [])",
+			args: args{
+				index:  0,
+				params: []string{},
+			},
+			want: UnknownParam,
+		},
+		{
+			name: "getParamsAt(-1, ['1', '2', '3', '4', '5'])",
+			args: args{
+				index:  -1,
+				params: []string{"1", "2", "3", "4", "5"},
+			},
+			want: UnknownParam,
+		},
+		{
+			name: "getParamsAt(5, ['1', '2', '3', '4', '5'])",
+			args: args{
+				index:  5,
+				params: []string{"1", "2", "3", "4", "5"},
+			},
+			want: UnknownParam,
+		},
+		{
+			name: "getParamsAt(0, ['1', '2', '3', '4', '5'])",
+			args: args{
+				index:  0,
+				params: []string{"1", "2", "3", "4", "5"},
+			},
+			want: "1",
+		},
+		{
+			name: "getParamsAt(4, ['1', '2', '3', '4', '5'])",
+			args: args{
+				index:  4,
+				params: []string{"1", "2", "3", "4", "5"},
+			},
+			want: "5",
+		},
+		{
+			name: "getParamsAt(2, ['1', '2', '3', '4', '5'])",
+			args: args{
+				index:  2,
+				params: []string{"1", "2", "3", "4", "5"},
+			},
+			want: "3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetParamAt(tt.args.index, tt.args.params); got != tt.want {
+				t.Errorf("getParamAt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPatternErrorMatcher_Run(t *testing.T) {
+	type fields struct {
+		defaultBuilder   DetailedErrorBuilder
+		patternToBuilder PatternToDetailedErrorBuilder
+	}
+	type args struct {
+		msg string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   step.Recommendation
+	}{
+		{
+			name: "Run with defaultBuilder",
+			fields: fields{
+				defaultBuilder: func(params ...string) DetailedError {
+					return DetailedError{
+						Title:       "T",
+						Description: "D",
+					}
+				},
+				patternToBuilder: map[string]DetailedErrorBuilder{},
+			},
+			args: args{
+				msg: "Test",
+			},
+			want: step.Recommendation{
+				DetailedErrorRecKey: DetailedError{
+					Title:       "T",
+					Description: "D",
+				},
+			},
+		},
+		{
+			name: "Run with patternBuilder",
+			fields: fields{
+				defaultBuilder: func(params ...string) DetailedError {
+					return DetailedError{
+						Title:       "DefaultTitle",
+						Description: "DefaultDesc",
+					}
+				},
+				patternToBuilder: map[string]DetailedErrorBuilder{
+					"Test": func(params ...string) DetailedError {
+						return DetailedError{
+							Title:       "PatternTitle",
+							Description: "PatternDesc",
+						}
+					},
+				},
+			},
+			args: args{
+				msg: "Test",
+			},
+			want: step.Recommendation{
+				DetailedErrorRecKey: DetailedError{
+					Title:       "PatternTitle",
+					Description: "PatternDesc",
+				},
+			},
+		},
+		{
+			name: "Run with patternBuilder with param",
+			fields: fields{
+				defaultBuilder: func(params ...string) DetailedError {
+					return DetailedError{
+						Title:       "DefaultTitle",
+						Description: "DefaultDesc",
+					}
+				},
+				patternToBuilder: map[string]DetailedErrorBuilder{
+					"Test (.+)!": func(params ...string) DetailedError {
+						p := GetParamAt(0, params)
+						return DetailedError{
+							Title:       "PatternTitle",
+							Description: fmt.Sprintf("PatternDesc: '%s'", p),
+						}
+					},
+				},
+			},
+			args: args{
+				msg: "Test WithPatternParam!",
+			},
+			want: step.Recommendation{
+				DetailedErrorRecKey: DetailedError{
+					Title:       "PatternTitle",
+					Description: "PatternDesc: 'WithPatternParam'",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &PatternErrorMatcher{
+				DefaultBuilder:   tt.fields.defaultBuilder,
+				PatternToBuilder: tt.fields.patternToBuilder,
+			}
+			if got := m.Run(tt.args.msg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PatternErrorMatcher.Run() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/models/models.go
+++ b/models/models.go
@@ -1,5 +1,7 @@
 package models
 
+import "github.com/bitrise-io/bitrise-init/step"
+
 // BitriseConfigMap ...
 type BitriseConfigMap map[string]string
 
@@ -22,11 +24,8 @@ type Icons []Icon
 // ErrorWithRecommendations ...
 type ErrorWithRecommendations struct {
 	Error           string
-	Recommendations Recommendation
+	Recommendations step.Recommendation
 }
-
-// Recommendation interface
-type Recommendation map[string]interface{}
 
 // ErrorsWithRecommendations is an array with an Error and its Recommendations
 type ErrorsWithRecommendations []ErrorWithRecommendations

--- a/models/models.go
+++ b/models/models.go
@@ -1,7 +1,5 @@
 package models
 
-import "github.com/bitrise-io/bitrise-init/step"
-
 // BitriseConfigMap ...
 type BitriseConfigMap map[string]string
 
@@ -24,8 +22,11 @@ type Icons []Icon
 // ErrorWithRecommendations ...
 type ErrorWithRecommendations struct {
 	Error           string
-	Recommendations step.Recommendation
+	Recommendations Recommendation
 }
+
+// Recommendation interface
+type Recommendation map[string]interface{}
 
 // ErrorsWithRecommendations is an array with an Error and its Recommendations
 type ErrorsWithRecommendations []ErrorWithRecommendations

--- a/models/models.go
+++ b/models/models.go
@@ -32,12 +32,13 @@ type ErrorsWithRecommendations []ErrorWithRecommendations
 
 // ScanResultModel ...
 type ScanResultModel struct {
-	ScannerToOptionRoot               map[string]OptionNode                `json:"options,omitempty" yaml:"options,omitempty"`
-	ScannerToBitriseConfigMap         map[string]BitriseConfigMap          `json:"configs,omitempty" yaml:"configs,omitempty"`
-	ScannerToWarnings                 map[string]Warnings                  `json:"warnings,omitempty" yaml:"warnings,omitempty"`
-	ScannerToErrors                   map[string]Errors                    `json:"errors,omitempty" yaml:"errors,omitempty"`
-	ScannerToErrorsWithRecomendations map[string]ErrorsWithRecommendations `json:"errors_with_recommendations,omitempty" yaml:"errors_with_recommendations,omitempty"`
-	Icons                             []Icon                               `json:"-" yaml:"-"`
+	ScannerToOptionRoot                  map[string]OptionNode                `json:"options,omitempty" yaml:"options,omitempty"`
+	ScannerToBitriseConfigMap            map[string]BitriseConfigMap          `json:"configs,omitempty" yaml:"configs,omitempty"`
+	ScannerToWarnings                    map[string]Warnings                  `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+	ScannerToErrors                      map[string]Errors                    `json:"errors,omitempty" yaml:"errors,omitempty"`
+	ScannerToErrorsWithRecommendations   map[string]ErrorsWithRecommendations `json:"errors_with_recommendations,omitempty" yaml:"errors_with_recommendations,omitempty"`
+	ScannerToWarningsWithRecommendations map[string]ErrorsWithRecommendations `json:"warnings_with_recommendations,omitempty" yaml:"warnings_with_recommendations,omitempty"`
+	Icons                                []Icon                               `json:"-" yaml:"-"`
 }
 
 // AddError ...

--- a/models/models.go
+++ b/models/models.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/bitrise-io/bitrise-init/step"
+import (
+	"github.com/bitrise-io/bitrise-init/step"
+)
 
 // BitriseConfigMap ...
 type BitriseConfigMap map[string]string
@@ -50,4 +52,15 @@ func (result *ScanResultModel) AddError(platform string, errorMessage string) {
 		result.ScannerToErrors[platform] = []string{}
 	}
 	result.ScannerToErrors[platform] = append(result.ScannerToErrors[platform], errorMessage)
+}
+
+// AddErrorWithRecommendation ...
+func (result *ScanResultModel) AddErrorWithRecommendation(platform string, recommendation ErrorWithRecommendations) {
+	if result.ScannerToErrorsWithRecommendations == nil {
+		result.ScannerToErrorsWithRecommendations = map[string]ErrorsWithRecommendations{}
+	}
+	if result.ScannerToErrorsWithRecommendations[platform] == nil {
+		result.ScannerToErrorsWithRecommendations[platform] = ErrorsWithRecommendations{}
+	}
+	result.ScannerToErrorsWithRecommendations[platform] = append(result.ScannerToErrorsWithRecommendations[platform], recommendation)
 }

--- a/scanner/config.go
+++ b/scanner/config.go
@@ -182,11 +182,13 @@ func Config(searchDir string) models.ScanResultModel {
 		icons = append(icons, scannerOutput.icons...)
 	}
 	return models.ScanResultModel{
-		ScannerToOptionRoot:       scannerToOptions,
-		ScannerToBitriseConfigMap: scannerToConfigMap,
-		ScannerToWarnings:         scannerToWarnings,
-		ScannerToErrors:           scannerToErrors,
-		Icons:                     icons,
+		ScannerToOptionRoot:                  scannerToOptions,
+		ScannerToBitriseConfigMap:            scannerToConfigMap,
+		ScannerToWarnings:                    scannerToWarnings,
+		ScannerToErrors:                      scannerToErrors,
+		ScannerToErrorsWithRecommendations:   scannerToErrorsWithRecommendations,
+		ScannerToWarningsWithRecommendations: scannerToWarningsWithRecommendation,
+		Icons:                                icons,
 	}
 }
 

--- a/scanner/config.go
+++ b/scanner/config.go
@@ -27,9 +27,10 @@ const (
 )
 
 const (
-	optionsFailedTag     = "options_failed"
-	configsFailedTag     = "configs_failed"
-	detectPlatformFailed = "detect_platform_failed"
+	optionsFailedTag        = "options_failed"
+	configsFailedTag        = "configs_failed"
+	detectPlatformFailedTag = "detect_platform_failed"
+	noPlatformDetectedTag   = "no_platform_detected"
 )
 
 type scannerOutput struct {
@@ -219,12 +220,12 @@ func runScanner(detector scanners.ScannerInterface, searchDir string) scannerOut
 
 	if isDetect, err := detector.DetectPlatform(searchDir); err != nil {
 		data := detectorErrorData(detector.Name(), err)
-		analytics.LogError(detectPlatformFailed, data, "%s detector DetectPlatform failed", detector.Name())
+		analytics.LogError(detectPlatformFailedTag, data, "%s detector DetectPlatform failed", detector.Name())
 
 		log.TErrorf("Scanner failed, error: %s", err)
 
 		output.status = notDetected
-		output.AddWarnings(detectPlatformFailed, err.Error())
+		output.AddWarnings(detectPlatformFailedTag, err.Error())
 		return output
 	} else if !isDetect {
 		output.status = notDetected

--- a/scanner/config.go
+++ b/scanner/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bitrise-io/bitrise-init/analytics"
 	"github.com/bitrise-io/bitrise-init/models"
 	"github.com/bitrise-io/bitrise-init/scanners"
+	"github.com/bitrise-io/bitrise-init/step"
 	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -35,13 +36,23 @@ type scannerOutput struct {
 
 	// set if scanResultStatus is scanResultDetectedWithErrors
 	// errors returned by Config()
-	errors models.Errors
+	errors                    models.Errors
+	errorssWithRecommendation []step.Error
 
 	// set if scanResultStatus is scanResultDetected
 	options          models.OptionNode
 	configs          models.BitriseConfigMap
 	icons            models.Icons
 	excludedScanners []string
+}
+
+func (o *scannerOutput) AddError(tag, err string) {
+	recommendation := mapRecommendation(tag, err)
+	if recommendation != nil {
+		// o.errorssWithRecommendation = step.NewErrorWithRecommendations("bitrise-init", tag, errors.New(err), "", recommendation)
+	}
+
+	// return step.NewError("git-clone", tag, err, shortMsg)
 }
 
 // Config ...

--- a/scanner/config_test.go
+++ b/scanner/config_test.go
@@ -1,13 +1,14 @@
 package scanner
 
 import (
+	"github.com/bitrise-io/bitrise-init/errormapper"
 	"reflect"
 	"testing"
 
 	"github.com/bitrise-io/bitrise-init/models"
 )
 
-var NoKnowPlatformDetectedRecommendation = newDetailedErrorRecommendation(Detail{
+var NoKnowPlatformDetectedRecommendation = errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{
 	Title:       "We couldn’t recognize your platform.",
 	Description: "Our auto-configurator supports react-native, flutter, ionic, cordova, ios, macos, android, xamarin, fastlane projects. If you’re adding something else, skip this step and configure your Workflow manually.",
 })

--- a/scanner/config_test.go
+++ b/scanner/config_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/bitrise-io/bitrise-init/models"
 )
 
-var NoKnowPlatformDetectedRecommendation = errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{
-	Title:       "We couldn’t recognize your platform.",
-	Description: "Our auto-configurator supports react-native, flutter, ionic, cordova, ios, macos, android, xamarin, fastlane projects. If you’re adding something else, skip this step and configure your Workflow manually.",
+var GradlewNotFoundRecommendation = errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{
+	Title:       "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.",
+	Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`,
 })
 
 func Test_scannerOutput_AddErrors(t *testing.T) {
@@ -25,8 +25,8 @@ func Test_scannerOutput_AddErrors(t *testing.T) {
 	}{
 		{
 			name: "Mapped error",
-			args: args{tag: noPlatformDetectedTag, errs: []string{"No known platform detected"}},
-			want: scannerOutput{errorsWithRecommendation: []models.ErrorWithRecommendations{{Error: "No known platform detected", Recommendations: NoKnowPlatformDetectedRecommendation}}},
+			args: args{tag: optionsFailedTag, errs: []string{"No Gradle Wrapper (gradlew) found."}},
+			want: scannerOutput{errorsWithRecommendation: []models.ErrorWithRecommendations{{Error: "No Gradle Wrapper (gradlew) found.", Recommendations: GradlewNotFoundRecommendation}}},
 		},
 		{
 			name: "Not mapped error",

--- a/scanner/config_test.go
+++ b/scanner/config_test.go
@@ -1,0 +1,44 @@
+package scanner
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bitrise-io/bitrise-init/models"
+)
+
+var NoKnowPlatformDetectedRecommendation = newDetailedErrorRecommendation(Detail{
+	Title:       "We couldn’t recognize your platform.",
+	Description: "Our auto-configurator supports react-native, flutter, ionic, cordova, ios, macos, android, xamarin, fastlane projects. If you’re adding something else, skip this step and configure your Workflow manually.",
+})
+
+func Test_scannerOutput_AddErrors(t *testing.T) {
+	type args struct {
+		tag  string
+		errs []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want scannerOutput
+	}{
+		{
+			name: "Mapped error",
+			args: args{tag: noPlatformDetectedTag, errs: []string{"No known platform detected"}},
+			want: scannerOutput{errorsWithRecommendation: []models.ErrorWithRecommendations{{Error: "No known platform detected", Recommendations: NoKnowPlatformDetectedRecommendation}}},
+		},
+		{
+			name: "Not mapped error",
+			args: args{tag: configsFailedTag, errs: []string{"unexpected end of JSON input"}},
+			want: scannerOutput{errors: models.Errors{"unexpected end of JSON input"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := scannerOutput{}
+			if o.AddErrors(tt.args.tag, tt.args.errs...); !reflect.DeepEqual(o, tt.want) {
+				t.Errorf("mapRecommendation() = %v, want %v", o, tt.want)
+			}
+		})
+	}
+}

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -1,0 +1,16 @@
+package scanner
+
+import "github.com/bitrise-io/bitrise-init/step"
+
+func mapRecommendation(tag, errMsg string) step.Recommendation {
+	// msg := err.Error()
+	// switch tag {
+	// case "checkout_failed":
+	// 	matcher := newCheckoutFailedPatternErrorMatcher()
+	// 	return matcher.Run(msg)
+	// case "fetch_failed":
+	// 	fetchFailedMatcher := newFetchFailedPatternErrorMatcher()
+	// 	return fetchFailedMatcher.Run(msg)
+	// }
+	// return nil
+}

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -1,16 +1,167 @@
 package scanner
 
-import "github.com/bitrise-io/bitrise-init/models"
+import (
+	"fmt"
+	"regexp"
+	"strings"
 
-func mapRecommendation(tag, errMsg string) models.Recommendation {
-	// msg := err.Error()
-	// switch tag {
-	// case "checkout_failed":
-	// 	matcher := newCheckoutFailedPatternErrorMatcher()
-	// 	return matcher.Run(msg)
-	// case "fetch_failed":
-	// 	fetchFailedMatcher := newFetchFailedPatternErrorMatcher()
-	// 	return fetchFailedMatcher.Run(msg)
-	// }
+	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/bitrise-init/scanners"
+)
+
+// Detail ...
+type Detail struct {
+	Title       string
+	Description string
+}
+
+func newDetailedErrorRecommendation(detail Detail) models.Recommendation {
+	return models.Recommendation{
+		"DetailedError": map[string]string{
+			"Title":       detail.Title,
+			"Description": detail.Description,
+		},
+	}
+}
+
+// DetailBuilder ...
+type DetailBuilder = func(...string) Detail
+
+// PatternErrorMatcher ...
+type PatternErrorMatcher struct {
+	defaultHandler DetailBuilder
+	handlers       map[string]DetailBuilder
+}
+
+func newPatternErrorMatcher(defaultHandler DetailBuilder, handlers map[string]DetailBuilder) *PatternErrorMatcher {
+	m := PatternErrorMatcher{
+		handlers:       handlers,
+		defaultHandler: defaultHandler,
+	}
+
+	return &m
+}
+
+// Run ...
+func (m *PatternErrorMatcher) Run(msg string) models.Recommendation {
+	for pattern, handler := range m.handlers {
+		re := regexp.MustCompile(pattern)
+		if re.MatchString(msg) {
+			matches := re.FindStringSubmatch((msg))
+
+			if len(matches) > 1 {
+				matches = matches[1:]
+			}
+
+			if matches != nil {
+				detail := handler(matches...)
+				return newDetailedErrorRecommendation(detail)
+			}
+		}
+	}
+
+	detail := m.defaultHandler(msg)
+	return newDetailedErrorRecommendation(detail)
+}
+
+func mapRecommendation(tag, err string) models.Recommendation {
+	var matcher *PatternErrorMatcher
+	switch tag {
+	case noPlatformDetectedTag:
+		matcher = newNoPlatformDetectedMatcher()
+	case detectPlatformFailedTag:
+		matcher = newDetectPlatformFailedMatcher()
+	case optionsFailedTag:
+		matcher = newOptionsFailedMatcher()
+	}
+
+	if matcher != nil {
+		return matcher.Run(err)
+	}
 	return nil
+}
+
+// noPlatformDetectedTag
+func newNoPlatformDetectedMatcher() *PatternErrorMatcher {
+	return newPatternErrorMatcher(
+		newNoPlatformDetectedGenericDetail,
+		nil,
+	)
+}
+
+func newNoPlatformDetectedGenericDetail(params ...string) Detail {
+	return Detail{
+		Title:       "We couldn’t recognize your platform.",
+		Description: fmt.Sprintf("Our auto-configurator supports %s projects. If you’re adding something else, skip this step and configure your Workflow manually.", strings.Join(availableScanners(), ", ")),
+	}
+}
+
+func availableScanners() (scannerNames []string) {
+	for _, scanner := range scanners.ProjectScanners {
+		scannerNames = append(scannerNames, scanner.Name())
+	}
+	for _, scanner := range scanners.AutomationToolScanners {
+		scannerNames = append(scannerNames, scanner.Name())
+	}
+	return
+}
+
+// detectPlatformFailedTag
+func newDetectPlatformFailedMatcher() *PatternErrorMatcher {
+	return newPatternErrorMatcher(
+		newDetectPlatformFailedGenericDetail,
+		nil,
+	)
+}
+
+func newDetectPlatformFailedGenericDetail(params ...string) Detail {
+	err := params[0]
+	return Detail{
+		Title:       "We couldn’t parse your project files.",
+		Description: fmt.Sprintf("Our auto-configurator returned the following error:\n%s", err),
+	}
+}
+
+// optionsFailedTag
+func newOptionsFailedMatcher() *PatternErrorMatcher {
+	return newPatternErrorMatcher(
+		newOptionsFailedGenericDetail,
+		map[string]DetailBuilder{
+			`No Gradle Wrapper (gradlew) found.`: newGradlewNotFoundDetail,
+			`app\.json file \((.+)\) missing or empty (.+) entry\nThe app\.json file needs to contain:`:                             newAppJSONIssueDetail,
+			`app\.json file \((.+)\) missing or empty (.+) entry\nIf the project uses Expo Kit the app.json file needs to contain:`: newExpoAppJSONIssueDetail,
+		},
+	)
+}
+
+var newOptionsFailedGenericDetail = newDetectPlatformFailedGenericDetail
+
+func newGradlewNotFoundDetail(params ...string) Detail {
+	return Detail{
+		Title:       "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.",
+		Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`,
+	}
+}
+
+func newAppJSONIssueDetail(params ...string) Detail {
+	appJSONPath := params[0]
+	entryName := params[1]
+	return Detail{
+		Title: fmt.Sprintf("Your app.json file (%s) doesn’t have a %s field.", appJSONPath, entryName),
+		Description: `The app.json file needs to contain the following entries:
+- name
+- displayName`,
+	}
+}
+
+func newExpoAppJSONIssueDetail(params ...string) Detail {
+	appJSONPath := params[0]
+	entryName := params[1]
+	return Detail{
+		Title: fmt.Sprintf("Your app.json file (%s) doesn’t have a %s field.", appJSONPath, entryName),
+		Description: `If your project uses Expo Kit, the app.json file needs to contain the following entries:
+- expo/name
+- expo/ios/bundleIdentifier
+- expo/android/package`,
+	}
 }

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -127,7 +127,7 @@ func newOptionsFailedMatcher() *PatternErrorMatcher {
 	return newPatternErrorMatcher(
 		newOptionsFailedGenericDetail,
 		map[string]DetailBuilder{
-			`No Gradle Wrapper (gradlew) found.`: newGradlewNotFoundDetail,
+			`No Gradle Wrapper \(gradlew\) found\.`:                                                                                 newGradlewNotFoundDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nThe app\.json file needs to contain:`:                             newAppJSONIssueDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nIf the project uses Expo Kit the app.json file needs to contain:`: newExpoAppJSONIssueDetail,
 		},

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -12,5 +12,5 @@ func mapRecommendation(tag, errMsg string) step.Recommendation {
 	// 	fetchFailedMatcher := newFetchFailedPatternErrorMatcher()
 	// 	return fetchFailedMatcher.Run(msg)
 	// }
-	// return nil
+	return nil
 }

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -21,8 +21,6 @@ func newPatternErrorMatcher(defaultBuilder errormapper.DetailedErrorBuilder, pat
 func mapRecommendation(tag, err string) step.Recommendation {
 	var matcher *errormapper.PatternErrorMatcher
 	switch tag {
-	case noPlatformDetectedTag:
-		matcher = newNoPlatformDetectedMatcher()
 	case detectPlatformFailedTag:
 		matcher = newDetectPlatformFailedMatcher()
 	case optionsFailedTag:
@@ -35,15 +33,7 @@ func mapRecommendation(tag, err string) step.Recommendation {
 	return nil
 }
 
-// noPlatformDetectedTag
-func newNoPlatformDetectedMatcher() *errormapper.PatternErrorMatcher {
-	return newPatternErrorMatcher(
-		newNoPlatformDetectedGenericDetail,
-		nil,
-	)
-}
-
-func newNoPlatformDetectedGenericDetail(params ...string) errormapper.DetailedError {
+func newNoPlatformDetectedGenericDetail() errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "We couldn’t recognize your platform.",
 		Description: fmt.Sprintf("Our auto-configurator supports %s projects. If you’re adding something else, skip this step and configure your Workflow manually.", strings.Join(availableScanners(), ", ")),
@@ -90,7 +80,7 @@ func newOptionsFailedMatcher() *errormapper.PatternErrorMatcher {
 
 var newOptionsFailedGenericDetail = newDetectPlatformFailedGenericDetail
 
-func newGradlewNotFoundDetail(params ...string) errormapper.DetailedError {
+func newGradlewNotFoundDetail(...string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.",
 		Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`,

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -2,70 +2,24 @@ package scanner
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
+	"github.com/bitrise-io/bitrise-init/errormapper"
 	"github.com/bitrise-io/bitrise-init/scanners"
 	"github.com/bitrise-io/bitrise-init/step"
 )
 
-// Detail ...
-type Detail struct {
-	Title       string
-	Description string
-}
-
-func newDetailedErrorRecommendation(detail Detail) step.Recommendation {
-	return step.Recommendation{
-		"DetailedError": map[string]string{
-			"Title":       detail.Title,
-			"Description": detail.Description,
-		},
-	}
-}
-
-// DetailBuilder ...
-type DetailBuilder = func(...string) Detail
-
-// PatternErrorMatcher ...
-type PatternErrorMatcher struct {
-	defaultHandler DetailBuilder
-	handlers       map[string]DetailBuilder
-}
-
-func newPatternErrorMatcher(defaultHandler DetailBuilder, handlers map[string]DetailBuilder) *PatternErrorMatcher {
-	m := PatternErrorMatcher{
-		handlers:       handlers,
-		defaultHandler: defaultHandler,
+func newPatternErrorMatcher(defaultBuilder errormapper.DetailedErrorBuilder, patternToBuilder map[string]errormapper.DetailedErrorBuilder) *errormapper.PatternErrorMatcher {
+	m := errormapper.PatternErrorMatcher{
+		PatternToBuilder: patternToBuilder,
+		DefaultBuilder:   defaultBuilder,
 	}
 
 	return &m
 }
 
-// Run ...
-func (m *PatternErrorMatcher) Run(msg string) step.Recommendation {
-	for pattern, handler := range m.handlers {
-		re := regexp.MustCompile(pattern)
-		if re.MatchString(msg) {
-			matches := re.FindStringSubmatch((msg))
-
-			if len(matches) > 1 {
-				matches = matches[1:]
-			}
-
-			if matches != nil {
-				detail := handler(matches...)
-				return newDetailedErrorRecommendation(detail)
-			}
-		}
-	}
-
-	detail := m.defaultHandler(msg)
-	return newDetailedErrorRecommendation(detail)
-}
-
 func mapRecommendation(tag, err string) step.Recommendation {
-	var matcher *PatternErrorMatcher
+	var matcher *errormapper.PatternErrorMatcher
 	switch tag {
 	case noPlatformDetectedTag:
 		matcher = newNoPlatformDetectedMatcher()
@@ -82,15 +36,15 @@ func mapRecommendation(tag, err string) step.Recommendation {
 }
 
 // noPlatformDetectedTag
-func newNoPlatformDetectedMatcher() *PatternErrorMatcher {
+func newNoPlatformDetectedMatcher() *errormapper.PatternErrorMatcher {
 	return newPatternErrorMatcher(
 		newNoPlatformDetectedGenericDetail,
 		nil,
 	)
 }
 
-func newNoPlatformDetectedGenericDetail(params ...string) Detail {
-	return Detail{
+func newNoPlatformDetectedGenericDetail(params ...string) errormapper.DetailedError {
+	return errormapper.DetailedError{
 		Title:       "We couldn’t recognize your platform.",
 		Description: fmt.Sprintf("Our auto-configurator supports %s projects. If you’re adding something else, skip this step and configure your Workflow manually.", strings.Join(availableScanners(), ", ")),
 	}
@@ -107,26 +61,26 @@ func availableScanners() (scannerNames []string) {
 }
 
 // detectPlatformFailedTag
-func newDetectPlatformFailedMatcher() *PatternErrorMatcher {
+func newDetectPlatformFailedMatcher() *errormapper.PatternErrorMatcher {
 	return newPatternErrorMatcher(
 		newDetectPlatformFailedGenericDetail,
 		nil,
 	)
 }
 
-func newDetectPlatformFailedGenericDetail(params ...string) Detail {
+func newDetectPlatformFailedGenericDetail(params ...string) errormapper.DetailedError {
 	err := params[0]
-	return Detail{
+	return errormapper.DetailedError{
 		Title:       "We couldn’t parse your project files.",
 		Description: fmt.Sprintf("Our auto-configurator returned the following error:\n%s", err),
 	}
 }
 
 // optionsFailedTag
-func newOptionsFailedMatcher() *PatternErrorMatcher {
+func newOptionsFailedMatcher() *errormapper.PatternErrorMatcher {
 	return newPatternErrorMatcher(
 		newOptionsFailedGenericDetail,
-		map[string]DetailBuilder{
+		map[string]errormapper.DetailedErrorBuilder{
 			`No Gradle Wrapper \(gradlew\) found\.`:                                                                                 newGradlewNotFoundDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nThe app\.json file needs to contain:`:                             newAppJSONIssueDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nIf the project uses Expo Kit the app.json file needs to contain:`: newExpoAppJSONIssueDetail,
@@ -136,17 +90,17 @@ func newOptionsFailedMatcher() *PatternErrorMatcher {
 
 var newOptionsFailedGenericDetail = newDetectPlatformFailedGenericDetail
 
-func newGradlewNotFoundDetail(params ...string) Detail {
-	return Detail{
+func newGradlewNotFoundDetail(params ...string) errormapper.DetailedError {
+	return errormapper.DetailedError{
 		Title:       "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.",
 		Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`,
 	}
 }
 
-func newAppJSONIssueDetail(params ...string) Detail {
+func newAppJSONIssueDetail(params ...string) errormapper.DetailedError {
 	appJSONPath := params[0]
 	entryName := params[1]
-	return Detail{
+	return errormapper.DetailedError{
 		Title: fmt.Sprintf("Your app.json file (%s) doesn’t have a %s field.", appJSONPath, entryName),
 		Description: `The app.json file needs to contain the following entries:
 - name
@@ -154,10 +108,10 @@ func newAppJSONIssueDetail(params ...string) Detail {
 	}
 }
 
-func newExpoAppJSONIssueDetail(params ...string) Detail {
+func newExpoAppJSONIssueDetail(params ...string) errormapper.DetailedError {
 	appJSONPath := params[0]
 	entryName := params[1]
-	return Detail{
+	return errormapper.DetailedError{
 		Title: fmt.Sprintf("Your app.json file (%s) doesn’t have a %s field.", appJSONPath, entryName),
 		Description: `If your project uses Expo Kit, the app.json file needs to contain the following entries:
 - expo/name

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/bitrise-io/bitrise-init/models"
 	"github.com/bitrise-io/bitrise-init/scanners"
+	"github.com/bitrise-io/bitrise-init/step"
 )
 
 // Detail ...
@@ -15,8 +15,8 @@ type Detail struct {
 	Description string
 }
 
-func newDetailedErrorRecommendation(detail Detail) models.Recommendation {
-	return models.Recommendation{
+func newDetailedErrorRecommendation(detail Detail) step.Recommendation {
+	return step.Recommendation{
 		"DetailedError": map[string]string{
 			"Title":       detail.Title,
 			"Description": detail.Description,
@@ -43,7 +43,7 @@ func newPatternErrorMatcher(defaultHandler DetailBuilder, handlers map[string]De
 }
 
 // Run ...
-func (m *PatternErrorMatcher) Run(msg string) models.Recommendation {
+func (m *PatternErrorMatcher) Run(msg string) step.Recommendation {
 	for pattern, handler := range m.handlers {
 		re := regexp.MustCompile(pattern)
 		if re.MatchString(msg) {
@@ -64,7 +64,7 @@ func (m *PatternErrorMatcher) Run(msg string) models.Recommendation {
 	return newDetailedErrorRecommendation(detail)
 }
 
-func mapRecommendation(tag, err string) models.Recommendation {
+func mapRecommendation(tag, err string) step.Recommendation {
 	var matcher *PatternErrorMatcher
 	switch tag {
 	case noPlatformDetectedTag:

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -1,8 +1,8 @@
 package scanner
 
-import "github.com/bitrise-io/bitrise-init/step"
+import "github.com/bitrise-io/bitrise-init/models"
 
-func mapRecommendation(tag, errMsg string) step.Recommendation {
+func mapRecommendation(tag, errMsg string) models.Recommendation {
 	// msg := err.Error()
 	// switch tag {
 	// case "checkout_failed":

--- a/scanner/errors_test.go
+++ b/scanner/errors_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"github.com/bitrise-io/bitrise-init/errormapper"
 	"reflect"
 	"testing"
 
@@ -20,23 +21,23 @@ func Test_mapRecommendation(t *testing.T) {
 		{
 			name: "noPlatformDetected generic error",
 			args: args{tag: noPlatformDetectedTag, err: "No known platform detected"},
-			want: newDetailedErrorRecommendation(Detail{Title: "We couldn’t recognize your platform.", Description: "Our auto-configurator supports react-native, flutter, ionic, cordova, ios, macos, android, xamarin, fastlane projects. If you’re adding something else, skip this step and configure your Workflow manually."}),
+			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "We couldn’t recognize your platform.", Description: "Our auto-configurator supports react-native, flutter, ionic, cordova, ios, macos, android, xamarin, fastlane projects. If you’re adding something else, skip this step and configure your Workflow manually."}),
 		},
 		{
 			name: "detectPlatformFailed generic error",
 			args: args{tag: detectPlatformFailedTag, err: "No file found at path: Bitrise.xcodeproj/project.pbxproj"},
-			want: newDetailedErrorRecommendation(Detail{Title: "We couldn’t parse your project files.", Description: "Our auto-configurator returned the following error:\nNo file found at path: Bitrise.xcodeproj/project.pbxproj"}),
+			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "We couldn’t parse your project files.", Description: "Our auto-configurator returned the following error:\nNo file found at path: Bitrise.xcodeproj/project.pbxproj"}),
 		},
 		{
 			name: "optionsFailed generic error",
 			args: args{tag: optionsFailedTag, err: "No file found at path: ios/App/App/package.json"},
-			want: newDetailedErrorRecommendation(Detail{Title: "We couldn’t parse your project files.", Description: "Our auto-configurator returned the following error:\nNo file found at path: ios/App/App/package.json"}),
+			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "We couldn’t parse your project files.", Description: "Our auto-configurator returned the following error:\nNo file found at path: ios/App/App/package.json"}),
 		},
 		{
 			name: "optionsFailed gradlew error",
 			args: args{tag: optionsFailedTag, err: `<b>No Gradle Wrapper (gradlew) found.</b>
 Using a Gradle Wrapper (gradlew) is required, as the wrapper is what makes sure that the right Gradle version is installed and used for the build. More info/guide: <a>https://docs.gradle.org/current/userguide/gradle_wrapper.html</a>`},
-			want: newDetailedErrorRecommendation(Detail{Title: "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.", Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`}),
+			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.", Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`}),
 		},
 		{
 			name: "optionsFailed app.json error",
@@ -45,7 +46,7 @@ The app.json file needs to contain:
 - name
 - displayName
 entries.`},
-			want: newDetailedErrorRecommendation(Detail{Title: "Your app.json file (bitrise/app.json) doesn’t have a name field.", Description: `The app.json file needs to contain the following entries:
+			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "Your app.json file (bitrise/app.json) doesn’t have a name field.", Description: `The app.json file needs to contain the following entries:
 - name
 - displayName`}),
 		},
@@ -57,7 +58,7 @@ If the project uses Expo Kit the app.json file needs to contain:
 - expo/ios/bundleIdentifier
 - expo/android/package
 - entries.`},
-			want: newDetailedErrorRecommendation(Detail{Title: "Your app.json file (app.json) doesn’t have a expo/ios/bundleIdentifier field.", Description: `If your project uses Expo Kit, the app.json file needs to contain the following entries:
+			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "Your app.json file (app.json) doesn’t have a expo/ios/bundleIdentifier field.", Description: `If your project uses Expo Kit, the app.json file needs to contain the following entries:
 - expo/name
 - expo/ios/bundleIdentifier
 - expo/android/package`}),

--- a/scanner/errors_test.go
+++ b/scanner/errors_test.go
@@ -19,11 +19,6 @@ func Test_mapRecommendation(t *testing.T) {
 		want step.Recommendation
 	}{
 		{
-			name: "noPlatformDetected generic error",
-			args: args{tag: noPlatformDetectedTag, err: "No known platform detected"},
-			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "We couldn’t recognize your platform.", Description: "Our auto-configurator supports react-native, flutter, ionic, cordova, ios, macos, android, xamarin, fastlane projects. If you’re adding something else, skip this step and configure your Workflow manually."}),
-		},
-		{
 			name: "detectPlatformFailed generic error",
 			args: args{tag: detectPlatformFailedTag, err: "No file found at path: Bitrise.xcodeproj/project.pbxproj"},
 			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "We couldn’t parse your project files.", Description: "Our auto-configurator returned the following error:\nNo file found at path: Bitrise.xcodeproj/project.pbxproj"}),

--- a/scanner/errors_test.go
+++ b/scanner/errors_test.go
@@ -1,0 +1,73 @@
+package scanner
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bitrise-io/bitrise-init/models"
+)
+
+func Test_mapRecommendation(t *testing.T) {
+	type args struct {
+		tag string
+		err string
+	}
+	tests := []struct {
+		name string
+		args args
+		want models.Recommendation
+	}{
+		{
+			name: "noPlatformDetected generic error",
+			args: args{tag: noPlatformDetectedTag, err: "No known platform detected"},
+			want: newDetailedErrorRecommendation(Detail{Title: "We couldn’t recognize your platform.", Description: "Our auto-configurator supports react-native, flutter, ionic, cordova, ios, macos, android, xamarin, fastlane projects. If you’re adding something else, skip this step and configure your Workflow manually."}),
+		},
+		{
+			name: "detectPlatformFailed generic error",
+			args: args{tag: detectPlatformFailedTag, err: "No file found at path: Bitrise.xcodeproj/project.pbxproj"},
+			want: newDetailedErrorRecommendation(Detail{Title: "We couldn’t parse your project files.", Description: "Our auto-configurator returned the following error:\nNo file found at path: Bitrise.xcodeproj/project.pbxproj"}),
+		},
+		{
+			name: "optionsFailed generic error",
+			args: args{tag: optionsFailedTag, err: "No file found at path: ios/App/App/package.json"},
+			want: newDetailedErrorRecommendation(Detail{Title: "We couldn’t parse your project files.", Description: "Our auto-configurator returned the following error:\nNo file found at path: ios/App/App/package.json"}),
+		},
+		{
+			name: "optionsFailed gradlew error",
+			args: args{tag: optionsFailedTag, err: `<b>No Gradle Wrapper (gradlew) found.</b>
+Using a Gradle Wrapper (gradlew) is required, as the wrapper is what makes sure that the right Gradle version is installed and used for the build. More info/guide: <a>https://docs.gradle.org/current/userguide/gradle_wrapper.html</a>`},
+			want: newDetailedErrorRecommendation(Detail{Title: "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.", Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`}),
+		},
+		{
+			name: "optionsFailed app.json error",
+			args: args{tag: optionsFailedTag, err: `app.json file (bitrise/app.json) missing or empty name entry
+The app.json file needs to contain:
+- name
+- displayName
+entries.`},
+			want: newDetailedErrorRecommendation(Detail{Title: "Your app.json file (bitrise/app.json) doesn’t have a name field.", Description: `The app.json file needs to contain the following entries:
+- name
+- displayName`}),
+		},
+		{
+			name: "optionsFailed Expo app.json error",
+			args: args{tag: optionsFailedTag, err: `app.json file (app.json) missing or empty expo/ios/bundleIdentifier entry
+If the project uses Expo Kit the app.json file needs to contain:
+- expo/name
+- expo/ios/bundleIdentifier
+- expo/android/package
+- entries.`},
+			want: newDetailedErrorRecommendation(Detail{Title: "Your app.json file (app.json) doesn’t have a expo/ios/bundleIdentifier field.", Description: `If your project uses Expo Kit, the app.json file needs to contain the following entries:
+- expo/name
+- expo/ios/bundleIdentifier
+- expo/android/package`}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mapRecommendation(tt.args.tag, tt.args.err); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mapRecommendation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/scanner/errors_test.go
+++ b/scanner/errors_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/bitrise-init/step"
 )
 
 func Test_mapRecommendation(t *testing.T) {
@@ -15,7 +15,7 @@ func Test_mapRecommendation(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want models.Recommendation
+		want step.Recommendation
 	}{
 		{
 			name: "noPlatformDetected generic error",

--- a/scanner/result.go
+++ b/scanner/result.go
@@ -23,7 +23,7 @@ func GenerateScanResult(searchDir string) (models.ScanResultModel, bool) {
 	}
 
 	if len(platforms) == 0 {
-		analytics.LogError("no_platform_detected", nil, "No known platform detected")
+		analytics.LogError(noPlatformDetectedTag, nil, "No known platform detected")
 
 		scanResult.AddError("general", "No known platform detected")
 		return scanResult, false

--- a/scanner/result.go
+++ b/scanner/result.go
@@ -2,6 +2,8 @@ package scanner
 
 import (
 	"fmt"
+	"github.com/bitrise-io/bitrise-init/errormapper"
+	"github.com/bitrise-io/bitrise-init/step"
 	"os"
 	"path"
 	"path/filepath"
@@ -17,15 +19,21 @@ import (
 func GenerateScanResult(searchDir string) (models.ScanResultModel, bool) {
 	scanResult := Config(searchDir)
 
-	platforms := []string{}
+	var platforms []string
 	for platform := range scanResult.ScannerToOptionRoot {
 		platforms = append(platforms, platform)
 	}
 
 	if len(platforms) == 0 {
-		analytics.LogError(noPlatformDetectedTag, nil, "No known platform detected")
+		errorMessage := "No known platform detected"
+		analytics.LogError(noPlatformDetectedTag, nil, errorMessage)
 
-		scanResult.AddError("general", "No known platform detected")
+		scanResult.AddErrorWithRecommendation("general", models.ErrorWithRecommendations{
+			Error: errorMessage,
+			Recommendations: step.Recommendation{
+				errormapper.DetailedErrorRecKey: newNoPlatformDetectedGenericDetail(),
+			},
+		})
 		return scanResult, false
 	}
 	return scanResult, true

--- a/step/steperror.go
+++ b/step/steperror.go
@@ -1,14 +1,13 @@
 package step
 
+import "github.com/bitrise-io/bitrise-init/models"
+
 // Error is an error occuring top level in a step
 type Error struct {
 	StepID, Tag, ShortMsg string
 	Err                   error
-	Recommendations       Recommendation
+	Recommendations       models.Recommendation
 }
-
-// Recommendation interface
-type Recommendation map[string]interface{}
 
 // NewError constructs a step.Error
 func NewError(stepID, tag string, err error, shortMsg string) *Error {
@@ -21,7 +20,7 @@ func NewError(stepID, tag string, err error, shortMsg string) *Error {
 }
 
 // NewErrorWithRecommendations constructs a step.Error
-func NewErrorWithRecommendations(stepID, tag string, err error, shortMsg string, recommendations Recommendation) *Error {
+func NewErrorWithRecommendations(stepID, tag string, err error, shortMsg string, recommendations models.Recommendation) *Error {
 	return &Error{
 		StepID:          stepID,
 		Tag:             tag,

--- a/step/steperror.go
+++ b/step/steperror.go
@@ -1,13 +1,14 @@
 package step
 
-import "github.com/bitrise-io/bitrise-init/models"
-
 // Error is an error occuring top level in a step
 type Error struct {
 	StepID, Tag, ShortMsg string
 	Err                   error
-	Recommendations       models.Recommendation
+	Recommendations       Recommendation
 }
+
+// Recommendation interface
+type Recommendation map[string]interface{}
 
 // NewError constructs a step.Error
 func NewError(stepID, tag string, err error, shortMsg string) *Error {
@@ -20,7 +21,7 @@ func NewError(stepID, tag string, err error, shortMsg string) *Error {
 }
 
 // NewErrorWithRecommendations constructs a step.Error
-func NewErrorWithRecommendations(stepID, tag string, err error, shortMsg string, recommendations models.Recommendation) *Error {
+func NewErrorWithRecommendations(stepID, tag string, err error, shortMsg string, recommendations Recommendation) *Error {
 	return &Error{
 		StepID:          stepID,
 		Tag:             tag,


### PR DESCRIPTION
Map bitrise-init errors.
- first merge [git-clone step PR](https://github.com/bitrise-steplib/steps-git-clone/pull/126)
- use git-clone step's `errormapper` package rather than duplicating the generic error mapper functionality
- `models.Recommendation` needs to be moved back to `step` package