### PR TITLE
Ignore Android project scanner errors if we find an other proper project

### DIFF
--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -36,17 +36,14 @@ func (*Scanner) ExcludedScannerNames() []string {
 func (scanner *Scanner) DetectPlatform(searchDir string) (_ bool, err error) {
 	scanner.SearchDir = searchDir
 
-	scanner.ProjectRoots, err = walkMultipleFiles(searchDir, "build.gradle", "settings.gradle")
+	projectFiles := fileGroups{
+		{"build.gradle", "build.gradle.kts"},
+		{"settings.gradle", "settings.gradle.kts"},
+	}
+	scanner.ProjectRoots, err = walkMultipleFileGroups(searchDir, projectFiles)
 	if err != nil {
 		return false, fmt.Errorf("failed to search for build.gradle files, error: %s", err)
 	}
-
-	kotlinRoots, err := walkMultipleFiles(searchDir, "build.gradle.kts", "settings.gradle.kts")
-	if err != nil {
-		return false, fmt.Errorf("failed to search for build.gradle files, error: %s", err)
-	}
-
-	scanner.ProjectRoots = append(scanner.ProjectRoots, kotlinRoots...)
 
 	return len(scanner.ProjectRoots) > 0, err
 }
@@ -57,19 +54,24 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 	warnings := models.Warnings{}
 	appIconsAllProjects := models.Icons{}
 
+	foundOptions := false
+	var lastErr error = nil
 	for _, projectRoot := range scanner.ProjectRoots {
 		if err := checkGradlew(projectRoot); err != nil {
-			return models.OptionNode{}, warnings, nil, err
+			lastErr = err
+			continue
 		}
 
 		relProjectRoot, err := filepath.Rel(scanner.SearchDir, projectRoot)
 		if err != nil {
-			return models.OptionNode{}, warnings, nil, err
+			lastErr = err
+			continue
 		}
 
 		icons, err := LookupIcons(projectRoot, scanner.SearchDir)
 		if err != nil {
-			return models.OptionNode{}, warnings, nil, err
+			lastErr = err
+			continue
 		}
 		appIconsAllProjects = append(appIconsAllProjects, icons...)
 		iconIDs := make([]string, len(icons))
@@ -84,6 +86,10 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 		projectLocationOption.AddOption(relProjectRoot, moduleOption)
 		moduleOption.AddOption("app", variantOption)
 		variantOption.AddConfig("", configOption)
+		foundOptions = true
+	}
+	if !foundOptions && lastErr != nil {
+		return models.OptionNode{}, warnings, nil, lastErr
 	}
 
 	return *projectLocationOption, warnings, appIconsAllProjects, nil

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -40,7 +40,8 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (_ bool, err error) {
 		{"build.gradle", "build.gradle.kts"},
 		{"settings.gradle", "settings.gradle.kts"},
 	}
-	scanner.ProjectRoots, err = walkMultipleFileGroups(searchDir, projectFiles)
+	skipDirs := []string{".git", "CordovaLib", "node_modules"}
+	scanner.ProjectRoots, err = walkMultipleFileGroups(searchDir, projectFiles, skipDirs)
 	if err != nil {
 		return false, fmt.Errorf("failed to search for build.gradle files, error: %s", err)
 	}

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -11,6 +11,11 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
+type fileGroups [][]string
+
+var pathUtilIsPathExists = pathutil.IsPathExists
+var filePathWalk = filepath.Walk
+
 // Constants ...
 const (
 	ScannerName       = "android"
@@ -40,7 +45,7 @@ const (
 )
 
 func walk(src string, fn func(path string, info os.FileInfo) error) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+	return filePathWalk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -51,21 +56,27 @@ func walk(src string, fn func(path string, info os.FileInfo) error) error {
 	})
 }
 
-func checkFiles(path string, files ...string) (bool, error) {
-	for _, file := range files {
-		exists, err := pathutil.IsPathExists(filepath.Join(path, file))
-		if err != nil {
-			return false, err
+func checkFileGroups(path string, fileGroups fileGroups) (bool, error) {
+	for _, fileGroup := range fileGroups {
+		found := false
+		for _, file := range fileGroup {
+			exists, err := pathUtilIsPathExists(filepath.Join(path, file))
+			if err != nil {
+				return found, err
+			}
+			if exists {
+				found = true
+			}
 		}
-		if !exists {
+		if !found {
 			return false, nil
 		}
 	}
 	return true, nil
 }
 
-func walkMultipleFiles(searchDir string, files ...string) (matches []string, err error) {
-	match, err := checkFiles(searchDir, files...)
+func walkMultipleFileGroups(searchDir string, fileGroups fileGroups) (matches []string, err error) {
+	match, err := checkFileGroups(searchDir, fileGroups)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +88,7 @@ func walkMultipleFiles(searchDir string, files ...string) (matches []string, err
 			return err
 		}
 		if info.IsDir() {
-			match, err := checkFiles(path, files...)
+			match, err := checkFileGroups(path, fileGroups)
 			if err != nil {
 				return err
 			}

--- a/scanners/android/utility_test.go
+++ b/scanners/android/utility_test.go
@@ -41,7 +41,10 @@ func TestWalkMultipleFileGroups(t *testing.T) {
 	paths := []string{rootPath, "2", "3", "4", "5"}
 	filePathWalk = func(root string, walkFn filepath.WalkFunc) error {
 		for _, path := range paths {
-			_ = walkFn(path, TestFileInfo{}, nil)
+			err := walkFn(path, TestFileInfo{}, nil)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -118,8 +121,10 @@ func TestWalkMultipleFileGroups(t *testing.T) {
 			// Arrange
 			pathUtilIsPathExists = tc.pathExists
 			// Act
-			groups, _ := walkMultipleFileGroups(rootPath, projectFiles)
+			groups, err := walkMultipleFileGroups(rootPath, projectFiles)
+
 			// Assert
+			assert.NoError(t, err)
 			assert.Equal(t, groups, tc.expect)
 		})
 	}

--- a/scanners/android/utility_test.go
+++ b/scanners/android/utility_test.go
@@ -1,0 +1,139 @@
+package android
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type TestFileInfo struct {
+}
+
+func (t TestFileInfo) Name() string {
+	panic("implement me")
+}
+
+func (t TestFileInfo) Size() int64 {
+	panic("implement me")
+}
+
+func (t TestFileInfo) Mode() os.FileMode {
+	panic("implement me")
+}
+
+func (t TestFileInfo) ModTime() time.Time {
+	panic("implement me")
+}
+
+func (t TestFileInfo) IsDir() bool {
+	return true
+}
+
+func (t TestFileInfo) Sys() interface{} {
+	panic("implement me")
+}
+
+func TestWalkMultipleFileGroups(t *testing.T) {
+	rootPath := "1"
+	paths := []string{rootPath, "2", "3", "4", "5"}
+	filePathWalk = func(root string, walkFn filepath.WalkFunc) error {
+		for _, path := range paths {
+			_ = walkFn(path, TestFileInfo{}, nil)
+		}
+		return nil
+	}
+
+	projectFiles := fileGroups{
+		{"build.gradle", "build.gradle.kts"},
+		{"settings.gradle", "settings.gradle.kts"},
+	}
+
+	testCases := []struct {
+		name       string
+		pathExists func(string) (bool, error)
+		expect     []string
+	}{
+		{
+			name:       "Root folder contains build.gradle and settings.gradle",
+			pathExists: buildMatcher(map[string][]string{rootPath: {"build.gradle", "settings.gradle"}}),
+			expect:     []string{rootPath},
+		},
+		{
+			name:       "Root folder contains build.gradle.kts and settings.gradle.kts",
+			pathExists: buildMatcher(map[string][]string{rootPath: {"build.gradle.kts", "settings.gradle.kts"}}),
+			expect:     []string{rootPath},
+		},
+		{
+			name:       "Root folder contains build.gradle and settings.gradle.kts",
+			pathExists: buildMatcher(map[string][]string{rootPath: {"build.gradle", "settings.gradle.kts"}}),
+			expect:     []string{rootPath},
+		},
+		{
+			name:       "Non-root folder contains build.gradle and settings.gradle",
+			pathExists: buildMatcher(map[string][]string{paths[1]: {"build.gradle.kts", "settings.gradle.kts"}}),
+			expect:     []string{paths[1]},
+		},
+		{
+			name:       "Non-root folder contains build.gradle.kts and settings.gradle.kts",
+			pathExists: buildMatcher(map[string][]string{paths[2]: {"build.gradle.kts", "settings.gradle.kts"}}),
+			expect:     []string{paths[2]},
+		},
+		{
+			name:       "Non-root folder contains build.gradle.kts and settings.gradle",
+			pathExists: buildMatcher(map[string][]string{paths[2]: {"build.gradle.kts", "settings.gradle"}}),
+			expect:     []string{paths[2]},
+		},
+		{
+			name:       "Root folder and child folder contains build.gradle and settings.gradle",
+			pathExists: buildMatcher(map[string][]string{rootPath: {"build.gradle", "settings.gradle"}, paths[2]: {"build.gradle.kts", "settings.gradle.kts"}}),
+			expect:     []string{rootPath, paths[2]},
+		},
+		{
+			name:       "Two child folders contains build.gradle and settings.gradle",
+			pathExists: buildMatcher(map[string][]string{paths[1]: {"build.gradle", "settings.gradle"}, paths[2]: {"build.gradle.kts", "settings.gradle.kts"}}),
+			expect:     []string{paths[1], paths[2]},
+		},
+		{
+			name:       "No folder contains any gradle files",
+			pathExists: buildMatcher(map[string][]string{}),
+			expect:     nil,
+		},
+		{
+			name:       "Root folder only contains settings.gradle",
+			pathExists: buildMatcher(map[string][]string{rootPath: {"settings.gradle"}}),
+			expect:     nil,
+		},
+		{
+			name:       "Root folder only contains build.gradle",
+			pathExists: buildMatcher(map[string][]string{rootPath: {"build.gradle"}}),
+			expect:     nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			pathUtilIsPathExists = tc.pathExists
+			// Act
+			groups, _ := walkMultipleFileGroups(rootPath, projectFiles)
+			// Assert
+			assert.Equal(t, groups, tc.expect)
+		})
+	}
+}
+
+func buildMatcher(rootsAndPaths map[string][]string) func(path string) (bool, error) {
+	return func(path string) (bool, error) {
+		for key, paths := range rootsAndPaths {
+			for _, p := range paths {
+				if path == fmt.Sprintf("%s%c%s", key, filepath.Separator, p) {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
+}


### PR DESCRIPTION
* Unified gradle file lookup
* Written tests
* Only fail android project scanner if not other project is found proper