### PR TITLE
errormapper package update

### DIFF
--- a/errormapper/errormapper.go
+++ b/errormapper/errormapper.go
@@ -26,8 +26,14 @@ func NewDetailedErrorRecommendation(detailedError DetailedError) step.Recommenda
 	}
 }
 
+// DefaultDetailedErrorBuilder ...
+type DefaultDetailedErrorBuilder = func(errorMsg string) DetailedError
+
 // DetailedErrorBuilder ...
-type DetailedErrorBuilder = func(...string) DetailedError
+type DetailedErrorBuilder = func(errorMsg string, params ...string) DetailedError
+
+// PatternToDetailedErrorBuilder ...
+type PatternToDetailedErrorBuilder map[string]DetailedErrorBuilder
 
 // GetParamAt ...
 func GetParamAt(index int, params []string) string {
@@ -38,12 +44,9 @@ func GetParamAt(index int, params []string) string {
 	return res
 }
 
-// PatternToDetailedErrorBuilder ...
-type PatternToDetailedErrorBuilder map[string]DetailedErrorBuilder
-
 // PatternErrorMatcher ...
 type PatternErrorMatcher struct {
-	DefaultBuilder   DetailedErrorBuilder
+	DefaultBuilder   DefaultDetailedErrorBuilder
 	PatternToBuilder PatternToDetailedErrorBuilder
 }
 
@@ -58,7 +61,7 @@ func (m *PatternErrorMatcher) Run(msg string) step.Recommendation {
 			// [search_string] -> []
 			// [search_string, match1, ...] -> [match1, ...]
 			params := matches[1:]
-			detail := builder(params...)
+			detail := builder(msg, params...)
 			return NewDetailedErrorRecommendation(detail)
 		}
 	}

--- a/errormapper/errormapper_test.go
+++ b/errormapper/errormapper_test.go
@@ -120,7 +120,7 @@ func Test_getParamAt(t *testing.T) {
 
 func TestPatternErrorMatcher_Run(t *testing.T) {
 	type fields struct {
-		defaultBuilder   DetailedErrorBuilder
+		defaultBuilder   DefaultDetailedErrorBuilder
 		patternToBuilder PatternToDetailedErrorBuilder
 	}
 	type args struct {
@@ -135,7 +135,7 @@ func TestPatternErrorMatcher_Run(t *testing.T) {
 		{
 			name: "Run with defaultBuilder",
 			fields: fields{
-				defaultBuilder: func(params ...string) DetailedError {
+				defaultBuilder: func(errorMsg string) DetailedError {
 					return DetailedError{
 						Title:       "T",
 						Description: "D",
@@ -156,14 +156,14 @@ func TestPatternErrorMatcher_Run(t *testing.T) {
 		{
 			name: "Run with patternBuilder",
 			fields: fields{
-				defaultBuilder: func(params ...string) DetailedError {
+				defaultBuilder: func(errorMsg string) DetailedError {
 					return DetailedError{
 						Title:       "DefaultTitle",
 						Description: "DefaultDesc",
 					}
 				},
 				patternToBuilder: map[string]DetailedErrorBuilder{
-					"Test": func(params ...string) DetailedError {
+					"Test": func(errorMsg string, params ...string) DetailedError {
 						return DetailedError{
 							Title:       "PatternTitle",
 							Description: "PatternDesc",
@@ -184,14 +184,14 @@ func TestPatternErrorMatcher_Run(t *testing.T) {
 		{
 			name: "Run with patternBuilder with param",
 			fields: fields{
-				defaultBuilder: func(params ...string) DetailedError {
+				defaultBuilder: func(errorMsg string) DetailedError {
 					return DetailedError{
 						Title:       "DefaultTitle",
 						Description: "DefaultDesc",
 					}
 				},
 				patternToBuilder: map[string]DetailedErrorBuilder{
-					"Test (.+)!": func(params ...string) DetailedError {
+					"Test (.+)!": func(errorMsg string, params ...string) DetailedError {
 						p := GetParamAt(0, params)
 						return DetailedError{
 							Title:       "PatternTitle",

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bitrise-io/bitrise-init/step"
 )
 
-func newPatternErrorMatcher(defaultBuilder errormapper.DetailedErrorBuilder, patternToBuilder map[string]errormapper.DetailedErrorBuilder) *errormapper.PatternErrorMatcher {
+func newPatternErrorMatcher(defaultBuilder errormapper.DefaultDetailedErrorBuilder, patternToBuilder map[string]errormapper.DetailedErrorBuilder) *errormapper.PatternErrorMatcher {
 	m := errormapper.PatternErrorMatcher{
 		PatternToBuilder: patternToBuilder,
 		DefaultBuilder:   defaultBuilder,
@@ -58,11 +58,10 @@ func newDetectPlatformFailedMatcher() *errormapper.PatternErrorMatcher {
 	)
 }
 
-func newDetectPlatformFailedGenericDetail(params ...string) errormapper.DetailedError {
-	err := params[0]
+func newDetectPlatformFailedGenericDetail(errorMsg string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "We couldn’t parse your project files.",
-		Description: fmt.Sprintf("Our auto-configurator returned the following error:\n%s", err),
+		Description: fmt.Sprintf("Our auto-configurator returned the following error:\n%s", errorMsg),
 	}
 }
 
@@ -80,14 +79,14 @@ func newOptionsFailedMatcher() *errormapper.PatternErrorMatcher {
 
 var newOptionsFailedGenericDetail = newDetectPlatformFailedGenericDetail
 
-func newGradlewNotFoundDetail(...string) errormapper.DetailedError {
+func newGradlewNotFoundDetail(errorMsg string, params ...string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.",
 		Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`,
 	}
 }
 
-func newAppJSONIssueDetail(params ...string) errormapper.DetailedError {
+func newAppJSONIssueDetail(errorMsg string, params ...string) errormapper.DetailedError {
 	appJSONPath := params[0]
 	entryName := params[1]
 	return errormapper.DetailedError{
@@ -98,7 +97,7 @@ func newAppJSONIssueDetail(params ...string) errormapper.DetailedError {
 	}
 }
 
-func newExpoAppJSONIssueDetail(params ...string) errormapper.DetailedError {
+func newExpoAppJSONIssueDetail(errorMsg string, params ...string) errormapper.DetailedError {
 	appJSONPath := params[0]
 	entryName := params[1]
 	return errormapper.DetailedError{


### PR DESCRIPTION
PatternErrorMatcher.Run passes the original error message to DetailedErrorBuilders,
so that DetailedErrorBuilders can use the original error message.