### PR TITLE
Ignoring Android scanner errors resulting from icon lookup failures.

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -4,11 +4,30 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
-// LogError sends analytics log using log.RErrorf by setting the stepID.
-func LogError(tag string, data map[string]interface{}, format string, v ...interface{}) {
+const stepName = "bitrise-init"
+
+func initData(data map[string]interface{}) map[string]interface{} {
 	if data == nil {
 		data = map[string]interface{}{}
 	}
 	data["source"] = "scanner"
-	log.RErrorf("bitrise-init", tag, data, format, v...)
+	return data
+}
+
+// LogError sends analytics log using log.RErrorf by setting the stepID.
+func LogError(tag string, data map[string]interface{}, format string, v ...interface{}) {
+	log.RErrorf(stepName, tag, initData(data), format, v...)
+}
+
+// LogInfo sends analytics log using log.RInfof by setting the stepID.
+func LogInfo(tag string, data map[string]interface{}, format string, v ...interface{}) {
+	log.RInfof(stepName, tag, initData(data), format, v...)
+}
+
+// DetectorErrorData creates analytics data that includes the platform and error
+func DetectorErrorData(detector string, err error) map[string]interface{} {
+	return map[string]interface{}{
+		"detector": detector,
+		"error":    err.Error(),
+	}
 }

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -1,0 +1,48 @@
+package analytics
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_initData(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name       string
+		data, want map[string]interface{}
+	}{
+		{
+			name: "Empty data",
+			data: map[string]interface{}{},
+			want: map[string]interface{}{
+				"source": "scanner",
+			},
+		},
+		{
+			name: "nil data",
+			data: nil,
+			want: map[string]interface{}{
+				"source": "scanner",
+			},
+		},
+		{
+			name: "Existing data",
+			data: map[string]interface{}{
+				"A": "B",
+			},
+			want: map[string]interface{}{
+				"source": "scanner",
+				"A":      "B",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if got := initData(tt.data); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("initData() = %v, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -25,6 +25,15 @@ func Test_initData(t *testing.T) {
 			},
 		},
 		{
+			name: "source is overwritten",
+			data: map[string]interface{}{
+				"source": "A",
+			},
+			want: map[string]interface{}{
+				"source": "scanner",
+			},
+		},
+		{
 			name: "Existing data",
 			data: map[string]interface{}{
 				"A": "B",

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -6,8 +6,6 @@ import (
 )
 
 func Test_initData(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name       string
 		data, want map[string]interface{}
@@ -39,7 +37,6 @@ func Test_initData(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			if got := initData(tt.data); !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("initData() = %v, want %s", got, tt.want)
 			}

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/bitrise-io/bitrise-init/analytics"
 	"github.com/bitrise-io/bitrise-init/models"
 )
 
@@ -69,7 +70,7 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 
 		icons, err := LookupIcons(projectRoot, scanner.SearchDir)
 		if err != nil {
-			return models.OptionNode{}, warnings, nil, err
+			analytics.LogInfo("android-icon-lookup", analytics.DetectorErrorData("android", err), "Failed to lookup android icon from manifest")
 		}
 		appIconsAllProjects = append(appIconsAllProjects, icons...)
 		iconIDs := make([]string, len(icons))

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -70,7 +70,7 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 
 		icons, err := LookupIcons(projectRoot, scanner.SearchDir)
 		if err != nil {
-			analytics.LogInfo("android-icon-lookup", analytics.DetectorErrorData("android", err), "Failed to lookup android icon from manifest")
+			analytics.LogInfo("android-icon-lookup", analytics.DetectorErrorData("android", err), "Failed to lookup android icon")
 		}
 		appIconsAllProjects = append(appIconsAllProjects, icons...)
 		iconIDs := make([]string, len(icons))

--- a/scanners/android/icon.go
+++ b/scanners/android/icon.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/beevik/etree"
+	"github.com/bitrise-io/bitrise-init/analytics"
 	"github.com/bitrise-io/bitrise-init/models"
 	"github.com/bitrise-io/bitrise-init/utility"
 	"github.com/bitrise-io/go-utils/log"
@@ -25,30 +26,23 @@ func lookupIconName(manifestPth string) ([]icon, error) {
 	}
 
 	log.Debugf("Looking for app icons. Manifest path: %s", manifestPth)
-	parsedIcons, err := parseIconName(doc)
-	if err != nil {
-		return nil, err
-	}
-
-	return parsedIcons, nil
+	return parseIconName(doc)
 }
 
 // parseIconName fetches icon name from AndroidManifest.xml.
 func parseIconName(doc *etree.Document) ([]icon, error) {
 	man := doc.SelectElement("manifest")
 	if man == nil {
-		log.Debugf("Key manifest not found in manifest file")
-		return nil, nil
+		return nil, fmt.Errorf("Key manifest not found in manifest file")
 	}
 	app := man.SelectElement("application")
 	if app == nil {
-		log.Debugf("Key application not found in manifest file")
-		return nil, nil
+		return nil, fmt.Errorf("Key application not found in manifest file")
 	}
 	ic := app.SelectAttr("android:icon")
 	if ic == nil {
-		log.Debugf("Attribute not found in manifest file")
-		return nil, nil
+		// Gradle varaibles like ${appIcon} are not supported
+		return nil, fmt.Errorf("Attribute not found in manifest file")
 	}
 
 	iconPathParts := strings.Split(strings.TrimPrefix(ic.Value, "@"), "/")
@@ -105,7 +99,7 @@ func lookupIcons(projectDir string, basepath string) ([]string, error) {
 	for _, manifestPath := range manifestPaths {
 		icons, err := lookupIconName(manifestPath)
 		if err != nil {
-			return nil, err
+			analytics.LogInfo("android-icon-lookup", analytics.DetectorErrorData("android", err), "Failed to lookup android icon from manifest")
 		}
 		iconNames = append(iconNames, icons...)
 	}

--- a/scanners/android/icon.go
+++ b/scanners/android/icon.go
@@ -33,16 +33,16 @@ func lookupIconName(manifestPth string) ([]icon, error) {
 func parseIconName(doc *etree.Document) ([]icon, error) {
 	man := doc.SelectElement("manifest")
 	if man == nil {
-		return nil, fmt.Errorf("Key manifest not found in manifest file")
+		return nil, fmt.Errorf("key 'manifest' not found in AndroidManifest.xml")
 	}
 	app := man.SelectElement("application")
 	if app == nil {
-		return nil, fmt.Errorf("Key application not found in manifest file")
+		return nil, fmt.Errorf("key 'application' not found in AndroidManifest.xml")
 	}
 	ic := app.SelectAttr("android:icon")
 	if ic == nil {
 		// Gradle varaibles like ${appIcon} are not supported
-		return nil, fmt.Errorf("Attribute not found in manifest file")
+		return nil, fmt.Errorf("attribute 'android:icon' not found in AndroidManifest.xml")
 	}
 
 	iconPathParts := strings.Split(strings.TrimPrefix(ic.Value, "@"), "/")
@@ -99,8 +99,10 @@ func lookupIcons(projectDir string, basepath string) ([]string, error) {
 	for _, manifestPath := range manifestPaths {
 		icons, err := lookupIconName(manifestPath)
 		if err != nil {
-			analytics.LogInfo("android-icon-lookup", analytics.DetectorErrorData("android", err), "Failed to lookup android icon from manifest")
+			analytics.LogInfo("android-icon-lookup", analytics.DetectorErrorData("android", err), "Failed to lookup android icon")
+			continue
 		}
+
 		iconNames = append(iconNames, icons...)
 	}
 
@@ -111,6 +113,7 @@ func lookupIcons(projectDir string, basepath string) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
+
 			iconPaths = append(iconPaths, foundIconPaths...)
 		}
 	}


### PR DESCRIPTION
- If icon format is unsupported, does not fail, instead returns default icons.
- Send failures to analytics Info level log, does not return warnings to user