### PR TITLE
Act 902 supress ios icon errors

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -15,11 +15,19 @@ func initData(data map[string]interface{}) map[string]interface{} {
 }
 
 // LogError sends analytics log using log.RErrorf by setting the stepID.
+// Used for errors, returned to the consumer.
 func LogError(tag string, data map[string]interface{}, format string, v ...interface{}) {
 	log.RErrorf(stepName, tag, initData(data), format, v...)
 }
 
+// LogWarn sends analytics log using log.RInfof by setting the stepID.
+// Used for warnings, returned to the consumer.
+func LogWarn(tag string, data map[string]interface{}, format string, v ...interface{}) {
+	log.RWarnf(stepName, tag, initData(data), format, v...)
+}
+
 // LogInfo sends analytics log using log.RInfof by setting the stepID.
+// Used for internal errors (not returned to the consumer).
 func LogInfo(tag string, data map[string]interface{}, format string, v ...interface{}) {
 	log.RInfof(stepName, tag, initData(data), format, v...)
 }

--- a/scanner/config.go
+++ b/scanner/config.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -236,6 +237,10 @@ func runScanner(detector scanners.ScannerInterface, searchDir string) scannerOut
 
 	options, projectWarnings, icons, err := detector.Options()
 	output.AddWarnings(optionsFailedTag, []string(projectWarnings)...)
+	for _, warning := range projectWarnings {
+		data := detectorErrorData(detector.Name(), errors.New(warning))
+		analytics.LogWarn(optionsFailedTag, data, "%s detector Options warning", detector.Name())
+	}
 
 	if err != nil {
 		data := detectorErrorData(detector.Name(), err)

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/bitrise-io/bitrise-init/analytics"
 	"github.com/bitrise-io/bitrise-init/models"
 	"github.com/bitrise-io/bitrise-init/steps"
 	"github.com/bitrise-io/bitrise-init/utility"
@@ -18,6 +19,7 @@ import (
 const (
 	defaultConfigNameFormat = "default-%s-config"
 	configNameFormat        = "%s%s-config"
+	iconFailureTag          = "icon_lookup"
 )
 
 const (
@@ -373,9 +375,8 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 				if !excludeAppIcon {
 					icons, err := lookupIconByTargetName(projectPath, target.Name, searchDir)
 					if err != nil {
-						warningMsg := fmt.Sprintf("could not get icons for app: %s, error: %s", projectPath, err)
-						log.Warnf(warningMsg)
-						warnings = append(warnings, warningMsg)
+						log.Warnf("could not get icons for app: %s, error: %s", projectPath, err)
+						analytics.LogInfo(iconFailureTag, analytics.DetectorErrorData(string(XcodeProjectTypeIOS), err), "Failed to lookup ios icons")
 					}
 					iconsForAllProjects = append(iconsForAllProjects, icons...)
 					for _, icon := range icons {
@@ -402,9 +403,8 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 				if !excludeAppIcon {
 					icons, err := lookupIconBySchemeName(projectPath, scheme.Name, searchDir)
 					if err != nil {
-						warningMsg := fmt.Sprintf("could not get icons for app: %s, error: %s", projectPath, err)
-						log.Warnf(warningMsg)
-						warnings = append(warnings, warningMsg)
+						log.Warnf("could not get icons for app: %s, error: %s", projectPath, err)
+						analytics.LogInfo(iconFailureTag, analytics.DetectorErrorData(string(XcodeProjectTypeIOS), err), "Failed to lookup ios icons")
 					}
 					iconsForAllProjects = append(iconsForAllProjects, icons...)
 					for _, icon := range icons {
@@ -456,9 +456,8 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 					if !excludeAppIcon {
 						icons, err := lookupIconByTargetName(project.Pth, target.Name, searchDir)
 						if err != nil {
-							warningMsg := fmt.Sprintf("could not get icons for app: %s, error: %s", project.Pth, err)
-							log.Warnf(warningMsg)
-							warnings = append(warnings, warningMsg)
+							log.Warnf("could not get icons for app: %s, error: %s", project.Pth, err)
+							analytics.LogInfo(iconFailureTag, analytics.DetectorErrorData(string(XcodeProjectTypeIOS), err), "Failed to lookup ios icons")
 						}
 						iconsForAllProjects = append(iconsForAllProjects, icons...)
 						for _, icon := range icons {
@@ -503,9 +502,8 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 
 					icons, err := lookupIconBySchemeName(projectPath, scheme.Name, searchDir)
 					if err != nil {
-						warningMsg := fmt.Sprintf("could not get icons for app: %s, error: %s", projectPath, err)
-						log.Warnf(warningMsg)
-						warnings = append(warnings, warningMsg)
+						log.Warnf("could not get icons for app: %s, error: %s", projectPath, err)
+						analytics.LogInfo(iconFailureTag, analytics.DetectorErrorData(string(XcodeProjectTypeIOS), err), "Failed to lookup ios icons")
 					}
 					iconsForAllProjects = append(iconsForAllProjects, icons...)
 					for _, icon := range icons {


### PR DESCRIPTION
Supressing ios icon lookup failures.

Sending warnings returned by Options to analytics.