### PR TITLE
Showing a better error message to Ionic Capacitor users

### DIFF
--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -32,6 +32,7 @@ func stacks() []string {
 		"osx-xcode-12.0.x",
 		"osx-xcode-12.1.x",
 		"osx-xcode-12.2.x",
+		"osx-xcode-12.3.x",
 		"osx-xcode-9.4.x",
 		"osx-xcode-edge",
 	}

--- a/scanner/config.go
+++ b/scanner/config.go
@@ -186,12 +186,12 @@ func Config(searchDir string) models.ScanResultModel {
 	for scanner, scannerOutput := range scannerToOutput {
 		// Currently the tests except an empty warning list if no warnings
 		// are created in the not detect case.
-		if scannerOutput.status == notDetected && len(scannerOutput.warnings) > 0 ||
+		if scannerOutput.status == notDetected && (len(scannerOutput.warnings) > 0 || len(scannerOutput.warningsWithRecommendation) > 0) ||
 			scannerOutput.status != notDetected {
 			scannerToWarnings[scanner] = scannerOutput.warnings
 			scannerToWarningsWithRecommendation[scanner] = scannerOutput.warningsWithRecommendation
 		}
-		if len(scannerOutput.errors) > 0 &&
+		if (len(scannerOutput.errors) > 0 || len(scannerOutput.errorsWithRecommendation) > 0) &&
 			(scannerOutput.status == detected || scannerOutput.status == detectedWithErrors) {
 			scannerToErrors[scanner] = scannerOutput.errors
 			scannerToErrorsWithRecommendations[scanner] = scannerOutput.errorsWithRecommendation

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -88,7 +88,7 @@ func newOptionsFailedMatcher() *errormapper.PatternErrorMatcher {
 			`No Gradle Wrapper \(gradlew\) found\.`:                                                                                 newGradlewNotFoundDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nThe app\.json file needs to contain:`:                             newAppJSONIssueDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nIf the project uses Expo Kit the app.json file needs to contain:`: newExpoAppJSONIssueDetail,
-			`Cordova config.xml not found.`:                                                                                         newIonicCapacitorNotSupportedIssuesDetail,
+			`Cordova config.xml not found.`:                                                                                         newIonicCapacitorNotSupportedIssueDetail,
 		},
 	)
 }
@@ -125,7 +125,7 @@ func newExpoAppJSONIssueDetail(errorMsg string, params ...string) errormapper.De
 	}
 }
 
-func newIonicCapacitorNotSupportedIssuesDetail(errorMsg string, params ...string) errormapper.DetailedError {
+func newIonicCapacitorNotSupportedIssueDetail(errorMsg string, params ...string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "We couldn’t find your cordova.xml file.",
 		Description: `Our auto-configurator only supports Ionic projects with Cordova at the moment. If you’re trying to add a project with Ionic Capacitor or something else, skip auto-configuration and set up your project manually.`,

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -88,6 +88,7 @@ func newOptionsFailedMatcher() *errormapper.PatternErrorMatcher {
 			`No Gradle Wrapper \(gradlew\) found\.`:                                                                                 newGradlewNotFoundDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nThe app\.json file needs to contain:`:                             newAppJSONIssueDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nIf the project uses Expo Kit the app.json file needs to contain:`: newExpoAppJSONIssueDetail,
+			`Cordova config.xml not found.`:                                                                                         newIonicCapacitorNotSupportedIssuesDetail,
 		},
 	)
 }
@@ -121,5 +122,12 @@ func newExpoAppJSONIssueDetail(errorMsg string, params ...string) errormapper.De
 - expo/name
 - expo/ios/bundleIdentifier
 - expo/android/package`,
+	}
+}
+
+func newIonicCapacitorNotSupportedIssuesDetail(errorMsg string, params ...string) errormapper.DetailedError {
+	return errormapper.DetailedError{
+		Title:       "We couldn’t find your cordova.xml file.",
+		Description: `Our auto-configurator only supports Ionic projects with Cordova at the moment. If you’re trying to add a project with Ionic Capacitor or something else, skip auto-configuration and set up your project manually.`,
 	}
 }

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -128,6 +128,6 @@ func newExpoAppJSONIssueDetail(errorMsg string, params ...string) errormapper.De
 func newIonicCapacitorNotSupportedIssueDetail(errorMsg string, params ...string) errormapper.DetailedError {
 	return errormapper.DetailedError{
 		Title:       "We couldn’t find your cordova.xml file.",
-		Description: `Our auto-configurator only supports Ionic projects with Cordova at the moment. If you’re trying to add a project with Ionic Capacitor or something else, skip auto-configuration and set up your project manually.`,
+		Description: `Our auto-configurator only supports Ionic projects with Cordova at the moment. If you’re trying to add a project with Ionic Capacitor, or something else, some Steps in your automatically generated Workflow might fail. To fix this, replace the failing Steps with script Steps in the Workflow editor later.`,
 	}
 }

--- a/scanners/ionic/ionic.go
+++ b/scanners/ionic/ionic.go
@@ -51,7 +51,7 @@ const (
 
 // Scanner ...
 type Scanner struct {
-	cordovaConfigPth    string
+	ionicConfigPath     string
 	relCordovaConfigDir string
 	searchDir           string
 	hasKarmaJasmineTest bool
@@ -75,56 +75,28 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 		return false, fmt.Errorf("failed to search for files in (%s), error: %s", searchDir, err)
 	}
 
-	// Search for config.xml file
-	log.TInfof("Searching for config.xml file")
-
-	configXMLPth, err := cordova.FilterRootConfigXMLFile(fileList)
-	if err != nil {
-		return false, fmt.Errorf("failed to search for config.xml file, error: %s", err)
-	}
-
-	log.TPrintf("config.xml: %s", configXMLPth)
-
-	if configXMLPth == "" {
-		log.TPrintf("platform not detected")
-		return false, nil
-	}
-
-	widget, err := cordova.ParseConfigXML(configXMLPth)
-	if err != nil {
-		log.TPrintf("can not parse config.xml as a Cordova widget, error: %s", err)
-		log.TPrintf("platform not detected")
-		return false, nil
-	}
-
-	// ensure it is a cordova widget
-	if !strings.Contains(widget.XMLNSCDV, "cordova.apache.org") {
-		log.TPrintf("config.xml propert: xmlns:cdv does not contain cordova.apache.org")
-		log.TPrintf("platform not detected")
-		return false, nil
-	}
-
-	// ensure it is an ionic project
-	projectBaseDir := filepath.Dir(configXMLPth)
-
-	ionicProjectExist, err := pathutil.IsPathExists(filepath.Join(projectBaseDir, "ionic.project"))
+	// Ensure it is an ionic project
+	ionicConfigPath, err := FilterRootFile(fileList, "ionic.config.json")
 	if err != nil {
 		return false, fmt.Errorf("failed to check if project is an ionic project, error: %s", err)
 	}
 
-	ionicConfigExist, err := pathutil.IsPathExists(filepath.Join(projectBaseDir, "ionic.config.json"))
-	if err != nil {
-		return false, fmt.Errorf("failed to check if project is an ionic project, error: %s", err)
+	// Check the existence of the old ionic.project file
+	if ionicConfigPath == "" {
+		ionicConfigPath, err = FilterRootFile(fileList, "ionic.project")
+		if err != nil {
+			return false, fmt.Errorf("failed to check if project is an ionic project, error: %s", err)
+		}
 	}
 
-	if !ionicProjectExist && !ionicConfigExist {
-		log.Printf("no ionic.project file nor ionic.config.json found, seems to be a cordova project")
+	if ionicConfigPath == "" {
+		log.Printf("No ionic.project file nor ionic.config.json found.")
 		return false, nil
 	}
 
 	log.TSuccessf("Platform detected")
 
-	scanner.cordovaConfigPth = configXMLPth
+	scanner.ionicConfigPath = ionicConfigPath
 	scanner.searchDir = searchDir
 
 	return true, nil
@@ -143,7 +115,8 @@ func (Scanner) ExcludedScannerNames() []string {
 // Options ...
 func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, error) {
 	warnings := models.Warnings{}
-	projectRootDir := filepath.Dir(scanner.cordovaConfigPth)
+
+	projectRootDir := filepath.Dir(scanner.ionicConfigPath)
 
 	packagesJSONPth := filepath.Join(projectRootDir, "package.json")
 	packages, err := utility.ParsePackagesJSON(packagesJSONPth)
@@ -222,8 +195,24 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 	}
 	// ---
 
+	// Configure Cordova
+	cordovaConfigExist, err := pathutil.IsPathExists(filepath.Join(projectRootDir, "config.xml"))
+	if err != nil {
+		return models.OptionNode{},
+			warnings,
+			nil,
+			fmt.Errorf("failed to search for config.xml file, error: %s", err)
+	}
+
+	log.TPrintf("config.xml: %s", filepath.Join(projectRootDir, "config.xml"))
+
+	if !cordovaConfigExist {
+		warning := fmt.Sprintf("We only support Ionic Cordova apps at the moment. If you are trying to add an Ionic Capacitor project, that won't work correctly unfortunately. It's on our roadmap, we are planning to support it in the future.")
+		warnings = append(warnings, warning)
+	}
+
 	// Get relative config.xml dir
-	cordovaConfigDir := filepath.Dir(scanner.cordovaConfigPth)
+	cordovaConfigDir := filepath.Dir(scanner.ionicConfigPath)
 	relCordovaConfigDir, err := utility.RelPath(scanner.searchDir, cordovaConfigDir)
 	if err != nil {
 		return models.OptionNode{},

--- a/scanners/ionic/ionic.go
+++ b/scanners/ionic/ionic.go
@@ -207,7 +207,7 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 	log.TPrintf("config.xml: %s", filepath.Join(projectRootDir, "config.xml"))
 
 	if !cordovaConfigExist {
-		warning := fmt.Sprintf("We only support Ionic Cordova apps at the moment. If you are trying to add an Ionic Capacitor project, that won't work correctly unfortunately. It's on our roadmap, we are planning to support it in the future.")
+		warning := fmt.Sprintf("Cordova config.xml not found.")
 		warnings = append(warnings, warning)
 	}
 

--- a/scanners/ionic/ionic.go
+++ b/scanners/ionic/ionic.go
@@ -201,7 +201,7 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 		return models.OptionNode{},
 			warnings,
 			nil,
-			fmt.Errorf("failed to search for config.xml file, error: %s", err)
+			fmt.Errorf("failed to search for config.xml file: %s", err)
 	}
 
 	log.TPrintf("config.xml: %s", filepath.Join(projectRootDir, "config.xml"))

--- a/scanners/ionic/utility.go
+++ b/scanners/ionic/utility.go
@@ -1,0 +1,20 @@
+package ionic
+
+import (
+	"github.com/bitrise-io/bitrise-init/utility"
+)
+
+// FilterRootFile ...
+func FilterRootFile(fileList []string, fileName string) (string, error) {
+	allowBaseFilter := utility.BaseFilter(fileName, true)
+	files, err := utility.FilterPaths(fileList, allowBaseFilter)
+	if err != nil {
+		return "", err
+	}
+
+	if len(files) == 0 {
+		return "", nil
+	}
+
+	return files[0], nil
+}


### PR DESCRIPTION
### Changes

1. Having cordova.xml is not mandatory anymore for Ionic projects, but if it's missing we show a warning message to the user that atm we only support Ionic Cordova projects.
2. Adding warningsWithRecommendation and errorsWithRecommendation to the not detected projects' output.

Users will see the following while trying to add an Ionic Capacitor project:

![image](https://user-images.githubusercontent.com/5689177/100112461-886ca080-2e6f-11eb-8fa4-9424629e13a9.png)

