### PR TITLE
Detect iOS AppClips in ProjectScanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _bin/
 .bitrise*
 .gows*
 bitrise-init
+.vscode/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,14 +47,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3060b1a20d5eccc02b4dcf61127258fb3ca0070b3386d4326907417164a9bcdd"
+  digest = "1:47dc0de590d47f16a8c7d1c2bab1f620157ea2e2895e6c359f78befe09ecc9a9"
   name = "github.com/bitrise-io/go-xcode"
   packages = [
     "plistutil",
     "xcodeproj",
   ]
   pruneopts = "UT"
-  revision = "19cbfe6430acc193d779847a13be0b8585d866c1"
+  revision = "81c1cd57e28a647e2b6e323791b62e620b333cd9"
 
 [[projects]]
   branch = "master"
@@ -225,6 +225,7 @@
     "github.com/bitrise-io/xcode-project/xcscheme",
     "github.com/bitrise-io/xcode-project/xcworkspace",
     "github.com/google/go-cmp/cmp",
+    "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/urfave/cli",
     "gopkg.in/yaml.v2",

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -48,7 +48,7 @@ func TestIOS(t *testing.T) {
 		{
 			name:           "sample-apps-appclip",
 			repoURL:        "https://github.com/bitrise-io/sample-apps-ios-with-appclip.git",
-			expectedResult: sampleAppClip,
+			expectedResult: sampleAppClipResultYML,
 		},
 	}
 
@@ -647,7 +647,7 @@ warnings_with_recommendations:
   ios: []
 `, sampleAppsCarthageVersions...)
 
-var sampleAppClip = `options:
+var sampleAppClipResultYML = `options:
   ios:
     title: Project or Workspace path
     summary: The location of your Xcode project or Xcode workspace files, stored as

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -86,6 +86,22 @@ func TestIOS(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, strings.TrimSpace(sampleAppsCarthageResultYML), strings.TrimSpace(result))
 	}
+	t.Log("sample-apps-appclip")
+	{
+		sampleAppDir := filepath.Join(tmpDir, "sample-apps-appclip")
+		sampleAppURL := "https://github.com/bitrise-io/sample-apps-ios-with-appclip.git"
+		gitClone(t, sampleAppDir, sampleAppURL)
+
+		cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
+		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		scanResultPth := filepath.Join(sampleAppDir, "result.yml")
+
+		result, err := fileutil.ReadStringFromFile(scanResultPth)
+		require.NoError(t, err)
+		require.Equal(t, strings.TrimSpace(sampleAppClip), strings.TrimSpace(result))
+	}
 }
 
 var iosNoSharedSchemesVersions = []interface{}{
@@ -663,3 +679,155 @@ warnings:
 warnings_with_recommendations:
   ios: []
 `, sampleAppsCarthageVersions...)
+
+var sampleAppClip = `options:
+  ios:
+    title: Project or Workspace path
+    summary: The location of your Xcode project or Xcode workspace files, stored as
+      an Environment Variable. In your Workflows, you can specify paths relative to
+      this path.
+    env_key: BITRISE_PROJECT_PATH
+    type: selector
+    value_map:
+      Sample.xcworkspace:
+        title: Scheme name
+        summary: An Xcode scheme defines a collection of targets to build, a configuration
+          to use when building, and a collection of tests to execute. Only shared
+          schemes are detected automatically but you can use any scheme as a target
+          on Bitrise. You can change the scheme at any time in your Env Vars.
+        env_key: BITRISE_SCHEME
+        type: selector
+        value_map:
+          SampleAppClipApp:
+            title: ipa export method
+            summary: The export method used to create an .ipa file in your builds,
+              stored as an Environment Variable. You can change this at any time,
+              or even create several .ipa files with different export methods in the
+              same build.
+            env_key: BITRISE_EXPORT_METHOD
+            type: selector
+            value_map:
+              ad-hoc:
+                config: ios-app-clip-ad-hoc-config
+              app-store:
+                config: ios-app-clip-app-store-config
+              development:
+                config: ios-app-clip-development-config
+              enterprise:
+                config: ios-app-clip-enterprise-config
+configs:
+  ios:
+    ios-app-clip-ad-hoc-config: |
+      format_version: "8"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: ios
+      trigger_map:
+      - push_branch: '*'
+        workflow: primary
+      - pull_request_source_branch: '*'
+        workflow: primary
+      workflows:
+        primary:
+          steps:
+          - activate-ssh-key@4:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@4: {}
+          - cache-pull@2: {}
+          - script@1:
+              title: Do anything with Script step
+          - certificate-and-profile-installer@1: {}
+          - xcode-archive@3:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - export_method: $BITRISE_EXPORT_METHOD
+          - export-xcarchive@3:
+              inputs:
+              - product: app-clip
+          - deploy-to-bitrise-io@1: {}
+          - cache-push@2: {}
+    ios-app-clip-app-store-config: |
+      format_version: "8"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: ios
+      trigger_map:
+      - push_branch: '*'
+        workflow: primary
+      - pull_request_source_branch: '*'
+        workflow: primary
+      workflows:
+        primary:
+          steps:
+          - activate-ssh-key@4:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@4: {}
+          - cache-pull@2: {}
+          - script@1:
+              title: Do anything with Script step
+          - certificate-and-profile-installer@1: {}
+          - xcode-archive@3:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - export_method: $BITRISE_EXPORT_METHOD
+          - deploy-to-bitrise-io@1: {}
+          - cache-push@2: {}
+    ios-app-clip-development-config: |
+      format_version: "8"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: ios
+      trigger_map:
+      - push_branch: '*'
+        workflow: primary
+      - pull_request_source_branch: '*'
+        workflow: primary
+      workflows:
+        primary:
+          steps:
+          - activate-ssh-key@4:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@4: {}
+          - cache-pull@2: {}
+          - script@1:
+              title: Do anything with Script step
+          - certificate-and-profile-installer@1: {}
+          - xcode-archive@3:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - export_method: $BITRISE_EXPORT_METHOD
+          - export-xcarchive@3:
+              inputs:
+              - product: app-clip
+          - deploy-to-bitrise-io@1: {}
+          - cache-push@2: {}
+    ios-app-clip-enterprise-config: |
+      format_version: "8"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: ios
+      trigger_map:
+      - push_branch: '*'
+        workflow: primary
+      - pull_request_source_branch: '*'
+        workflow: primary
+      workflows:
+        primary:
+          steps:
+          - activate-ssh-key@4:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@4: {}
+          - cache-pull@2: {}
+          - script@1:
+              title: Do anything with Script step
+          - certificate-and-profile-installer@1: {}
+          - xcode-archive@3:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - export_method: $BITRISE_EXPORT_METHOD
+          - deploy-to-bitrise-io@1: {}
+          - cache-push@2: {}
+warnings:
+  ios: []
+warnings_with_recommendations:
+  ios: []`

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -18,89 +18,56 @@ func TestIOS(t *testing.T) {
 	tmpDir, err := pathutil.NormalizedOSTempDirPath("__ios__")
 	require.NoError(t, err)
 
-	t.Log("ios-no-shared-schemes")
-	{
-		sampleAppDir := filepath.Join(tmpDir, "ios-no-shared-scheme")
-		sampleAppURL := "https://github.com/bitrise-samples/ios-no-shared-schemes.git"
-		gitClone(t, sampleAppDir, sampleAppURL)
-
-		cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
-		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
-		require.NoError(t, err, out)
-
-		scanResultPth := filepath.Join(sampleAppDir, "result.yml")
-
-		result, err := fileutil.ReadStringFromFile(scanResultPth)
-		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(iosNoSharedSchemesResultYML), strings.TrimSpace(result))
+	type testCase struct {
+		name           string
+		repoURL        string
+		expectedResult string
 	}
 
-	t.Log("ios-cocoapods-at-root")
-	{
-		sampleAppDir := filepath.Join(tmpDir, "ios-cocoapods-at-root")
-		sampleAppURL := "https://github.com/bitrise-samples/ios-cocoapods-at-root.git"
-		gitClone(t, sampleAppDir, sampleAppURL)
-
-		cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
-		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
-		require.NoError(t, err, out)
-
-		scanResultPth := filepath.Join(sampleAppDir, "result.yml")
-
-		result, err := fileutil.ReadStringFromFile(scanResultPth)
-		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(iosCocoapodsAtRootResultYML), strings.TrimSpace(result))
+	testCases := []testCase{
+		{
+			name:           "ios-no-shared-schemes",
+			repoURL:        "https://github.com/bitrise-samples/ios-no-shared-schemes.git",
+			expectedResult: iosNoSharedSchemesResultYML,
+		},
+		{
+			name:           "ios-cocoapods-at-root",
+			repoURL:        "https://github.com/bitrise-samples/ios-cocoapods-at-root.git",
+			expectedResult: iosCocoapodsAtRootResultYML,
+		},
+		{
+			name:           "sample-apps-ios-watchkit",
+			repoURL:        "https://github.com/bitrise-io/sample-apps-ios-watchkit.git",
+			expectedResult: sampleAppsIosWatchkitResultYML,
+		},
+		{
+			name:           "sample-apps-carthage",
+			repoURL:        "https://github.com/bitrise-samples/sample-apps-carthage.git",
+			expectedResult: sampleAppsCarthageResultYML,
+		},
+		{
+			name:           "sample-apps-appclip",
+			repoURL:        "https://github.com/bitrise-io/sample-apps-ios-with-appclip.git",
+			expectedResult: sampleAppClip,
+		},
 	}
 
-	t.Log("sample-apps-ios-watchkit")
-	{
-		sampleAppDir := filepath.Join(tmpDir, "sample-apps-ios-watchkit")
-		sampleAppURL := "https://github.com/bitrise-io/sample-apps-ios-watchkit.git"
-		gitClone(t, sampleAppDir, sampleAppURL)
+	for _, testCase := range testCases {
+		t.Log(testCase.name)
+		{
+			sampleAppDir := filepath.Join(tmpDir, testCase.name)
+			gitClone(t, sampleAppDir, testCase.repoURL)
 
-		cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
-		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
-		require.NoError(t, err, out)
+			cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
+			out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+			require.NoError(t, err, out)
 
-		scanResultPth := filepath.Join(sampleAppDir, "result.yml")
+			scanResultPth := filepath.Join(sampleAppDir, "result.yml")
 
-		result, err := fileutil.ReadStringFromFile(scanResultPth)
-		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(sampleAppsIosWatchkitResultYML), strings.TrimSpace(result))
-	}
-
-	t.Log("sample-apps-carthage")
-	{
-		//
-		sampleAppDir := filepath.Join(tmpDir, "sample-apps-carthage")
-		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-carthage.git"
-		gitClone(t, sampleAppDir, sampleAppURL)
-
-		cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
-		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
-		require.NoError(t, err, out)
-
-		scanResultPth := filepath.Join(sampleAppDir, "result.yml")
-
-		result, err := fileutil.ReadStringFromFile(scanResultPth)
-		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(sampleAppsCarthageResultYML), strings.TrimSpace(result))
-	}
-	t.Log("sample-apps-appclip")
-	{
-		sampleAppDir := filepath.Join(tmpDir, "sample-apps-appclip")
-		sampleAppURL := "https://github.com/bitrise-io/sample-apps-ios-with-appclip.git"
-		gitClone(t, sampleAppDir, sampleAppURL)
-
-		cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
-		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
-		require.NoError(t, err, out)
-
-		scanResultPth := filepath.Join(sampleAppDir, "result.yml")
-
-		result, err := fileutil.ReadStringFromFile(scanResultPth)
-		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(sampleAppClip), strings.TrimSpace(result))
+			result, err := fileutil.ReadStringFromFile(scanResultPth)
+			require.NoError(t, err)
+			require.Equal(t, strings.TrimSpace(testCase.expectedResult), strings.TrimSpace(result))
+		}
 	}
 }
 

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -711,6 +711,7 @@ configs:
           - export-xcarchive@3:
               inputs:
               - product: app-clip
+              - export_method: $BITRISE_EXPORT_METHOD
           - deploy-to-bitrise-io@1: {}
           - cache-push@2: {}
     ios-app-clip-app-store-config: |
@@ -766,6 +767,7 @@ configs:
           - export-xcarchive@3:
               inputs:
               - product: app-clip
+              - export_method: $BITRISE_EXPORT_METHOD
           - deploy-to-bitrise-io@1: {}
           - cache-push@2: {}
     ios-app-clip-enterprise-config: |

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -62,6 +62,14 @@ const (
 // IosExportMethods ...
 var IosExportMethods = []string{"app-store", "ad-hoc", "enterprise", "development"}
 
+const (
+	// ExportXCArchiveProductInputKey ...
+	ExportXCArchiveProductInputKey = "product"
+
+	// ExportXCArchiveProductInputAppClipValue ...
+	ExportXCArchiveProductInputAppClipValue = "app-clip"
+)
+
 // MacExportMethods ...
 var MacExportMethods = []string{"app-store", "developer-id", "development", "none"}
 
@@ -86,15 +94,19 @@ type ConfigDescriptor struct {
 	HasPodfile           bool
 	CarthageCommand      string
 	HasTest              bool
+	HasAppClip           bool
+	ExportMethod         string
 	MissingSharedSchemes bool
 }
 
 // NewConfigDescriptor ...
-func NewConfigDescriptor(hasPodfile bool, carthageCommand string, hasXCTest bool, missingSharedSchemes bool) ConfigDescriptor {
+func NewConfigDescriptor(hasPodfile bool, carthageCommand string, hasXCTest, hasAppClip bool, exportMethod string, missingSharedSchemes bool) ConfigDescriptor {
 	return ConfigDescriptor{
 		HasPodfile:           hasPodfile,
 		CarthageCommand:      carthageCommand,
 		HasTest:              hasXCTest,
+		HasAppClip:           hasAppClip,
+		ExportMethod:         exportMethod,
 		MissingSharedSchemes: missingSharedSchemes,
 	}
 }
@@ -110,6 +122,9 @@ func (descriptor ConfigDescriptor) ConfigName(projectType XcodeProjectType) stri
 	}
 	if descriptor.HasTest {
 		qualifiers += "-test"
+	}
+	if descriptor.HasAppClip {
+		qualifiers += fmt.Sprintf("-app-clip-%s", descriptor.ExportMethod)
 	}
 	if descriptor.MissingSharedSchemes {
 		qualifiers += "-missing-shared-schemes"
@@ -385,7 +400,7 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 				}
 
 				for _, exportMethod := range exportMethods {
-					configDescriptor := NewConfigDescriptor(false, carthageCommand, target.HasXCTest, true)
+					configDescriptor := NewConfigDescriptor(false, carthageCommand, target.HasXCTest, target.HasAppClip, exportMethod, true)
 					configDescriptors = append(configDescriptors, configDescriptor)
 					configOption := models.NewConfigOption(configDescriptor.ConfigName(projectType), iconIDs)
 
@@ -413,7 +428,7 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 				}
 
 				for _, exportMethod := range exportMethods {
-					configDescriptor := NewConfigDescriptor(false, carthageCommand, scheme.HasXCTest, false)
+					configDescriptor := NewConfigDescriptor(false, carthageCommand, scheme.HasXCTest, schemeHasAppClipTarget(scheme, project.Targets), exportMethod, false)
 					configDescriptors = append(configDescriptors, configDescriptor)
 					configOption := models.NewConfigOption(configDescriptor.ConfigName(projectType), iconIDs)
 
@@ -466,7 +481,7 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 					}
 
 					for _, exportMethod := range exportMethods {
-						configDescriptor := NewConfigDescriptor(workspace.IsPodWorkspace, carthageCommand, target.HasXCTest, true)
+						configDescriptor := NewConfigDescriptor(workspace.IsPodWorkspace, carthageCommand, target.HasXCTest, target.HasAppClip, exportMethod, true)
 						configDescriptors = append(configDescriptors, configDescriptor)
 						configOption := models.NewConfigOption(configDescriptor.ConfigName(projectType), iconIDs)
 
@@ -512,7 +527,8 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 				}
 
 				for _, exportMethod := range exportMethods {
-					configDescriptor := NewConfigDescriptor(workspace.IsPodWorkspace, carthageCommand, scheme.HasXCTest, false)
+					// only add appclip for development and ad-hoc
+					configDescriptor := NewConfigDescriptor(workspace.IsPodWorkspace, carthageCommand, scheme.HasXCTest, schemeHasAppClipTarget(scheme, workspace.GetTargets()), exportMethod, false)
 					configDescriptors = append(configDescriptors, configDescriptor)
 					configOption := models.NewConfigOption(configDescriptor.ConfigName(projectType), iconIDs)
 
@@ -564,7 +580,16 @@ func GenerateDefaultOptions(projectType XcodeProjectType) models.OptionNode {
 }
 
 // GenerateConfigBuilder ...
-func GenerateConfigBuilder(projectType XcodeProjectType, hasPodfile, hasTest, missingSharedSchemes bool, carthageCommand string, isIncludeCache bool) models.ConfigBuilderModel {
+func GenerateConfigBuilder(
+	projectType XcodeProjectType,
+	hasPodfile,
+	hasTest,
+	hasAppClip,
+	missingSharedSchemes bool,
+	carthageCommand string,
+	isIncludeCache bool,
+	exportMethod string,
+) models.ConfigBuilderModel {
 	configBuilder := models.NewDefaultConfigBuilder()
 
 	// CI
@@ -588,8 +613,8 @@ func GenerateConfigBuilder(projectType XcodeProjectType, hasPodfile, hasTest, mi
 	}
 
 	xcodeStepInputModels := []envmanModels.EnvironmentItemModel{
-		envmanModels.EnvironmentItemModel{ProjectPathInputKey: "$" + ProjectPathInputEnvKey},
-		envmanModels.EnvironmentItemModel{SchemeInputKey: "$" + SchemeInputEnvKey},
+		{ProjectPathInputKey: "$" + ProjectPathInputEnvKey},
+		{SchemeInputKey: "$" + SchemeInputEnvKey},
 	}
 	xcodeArchiveStepInputModels := append(xcodeStepInputModels, envmanModels.EnvironmentItemModel{ExportMethodInputKey: "$" + ExportMethodInputEnvKey})
 
@@ -604,6 +629,10 @@ func GenerateConfigBuilder(projectType XcodeProjectType, hasPodfile, hasTest, mi
 		switch projectType {
 		case XcodeProjectTypeIOS:
 			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.XcodeArchiveStepListItem(xcodeArchiveStepInputModels...))
+
+			if shouldAppendAppClip(hasAppClip, exportMethod) {
+				appendExportAppClipStep(configBuilder, models.PrimaryWorkflowID)
+			}
 		case XcodeProjectTypeMacOS:
 			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.XcodeArchiveMacStepListItem(xcodeArchiveStepInputModels...))
 		}
@@ -635,14 +664,13 @@ func GenerateConfigBuilder(projectType XcodeProjectType, hasPodfile, hasTest, mi
 		switch projectType {
 		case XcodeProjectTypeIOS:
 			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeTestStepListItem(xcodeStepInputModels...))
+			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveStepListItem(xcodeArchiveStepInputModels...))
+
+			if shouldAppendAppClip(hasAppClip, exportMethod) {
+				appendExportAppClipStep(configBuilder, models.DeployWorkflowID)
+			}
 		case XcodeProjectTypeMacOS:
 			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeTestMacStepListItem(xcodeStepInputModels...))
-		}
-
-		switch projectType {
-		case XcodeProjectTypeIOS:
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveStepListItem(xcodeArchiveStepInputModels...))
-		case XcodeProjectTypeMacOS:
 			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveMacStepListItem(xcodeArchiveStepInputModels...))
 		}
 
@@ -672,7 +700,15 @@ func RemoveDuplicatedConfigDescriptors(configDescriptors []ConfigDescriptor, pro
 func GenerateConfig(projectType XcodeProjectType, configDescriptors []ConfigDescriptor, isIncludeCache bool) (models.BitriseConfigMap, error) {
 	bitriseDataMap := models.BitriseConfigMap{}
 	for _, descriptor := range configDescriptors {
-		configBuilder := GenerateConfigBuilder(projectType, descriptor.HasPodfile, descriptor.HasTest, descriptor.MissingSharedSchemes, descriptor.CarthageCommand, isIncludeCache)
+		configBuilder := GenerateConfigBuilder(
+			projectType,
+			descriptor.HasPodfile,
+			descriptor.HasTest,
+			descriptor.HasAppClip,
+			descriptor.MissingSharedSchemes,
+			descriptor.CarthageCommand,
+			isIncludeCache,
+			descriptor.ExportMethod)
 
 		config, err := configBuilder.Generate(string(projectType))
 		if err != nil {
@@ -704,8 +740,8 @@ func GenerateDefaultConfig(projectType XcodeProjectType, isIncludeCache bool) (m
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CocoapodsInstallStepListItem())
 
 	xcodeTestStepInputModels := []envmanModels.EnvironmentItemModel{
-		envmanModels.EnvironmentItemModel{ProjectPathInputKey: "$" + ProjectPathInputEnvKey},
-		envmanModels.EnvironmentItemModel{SchemeInputKey: "$" + SchemeInputEnvKey},
+		{ProjectPathInputKey: "$" + ProjectPathInputEnvKey},
+		{SchemeInputKey: "$" + SchemeInputEnvKey},
 	}
 	xcodeArchiveStepInputModels := append(xcodeTestStepInputModels, envmanModels.EnvironmentItemModel{ExportMethodInputKey: "$" + ExportMethodInputEnvKey})
 
@@ -729,7 +765,6 @@ func GenerateDefaultConfig(projectType XcodeProjectType, isIncludeCache bool) (m
 	switch projectType {
 	case XcodeProjectTypeIOS:
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeTestStepListItem(xcodeTestStepInputModels...))
-
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveStepListItem(xcodeArchiveStepInputModels...))
 	case XcodeProjectTypeMacOS:
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeTestMacStepListItem(xcodeTestStepInputModels...))
@@ -751,4 +786,28 @@ func GenerateDefaultConfig(projectType XcodeProjectType, isIncludeCache bool) (m
 	return models.BitriseConfigMap{
 		fmt.Sprintf(defaultConfigNameFormat, string(projectType)): string(data),
 	}, nil
+}
+
+func schemeHasAppClipTarget(scheme xcodeproj.SchemeModel, targets []xcodeproj.TargetModel) bool {
+	for _, target := range targets {
+		for _, referenceID := range scheme.BuildableReferenceIDs {
+			if referenceID == target.ID && target.HasAppClip {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func shouldAppendAppClip(hasAppClip bool, exportMethod string) bool {
+	return hasAppClip &&
+		(exportMethod == "development" || exportMethod == "ad-hoc")
+}
+
+func appendExportAppClipStep(configBuilder *models.ConfigBuilderModel, workflowID models.WorkflowID) {
+	exportXCArchiveStepInputModels := []envmanModels.EnvironmentItemModel{
+		{ExportXCArchiveProductInputKey: ExportXCArchiveProductInputAppClipValue},
+	}
+	configBuilder.AppendStepListItemsTo(workflowID, steps.ExportXCArchiveStepListItem(exportXCArchiveStepInputModels...))
 }

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -630,7 +630,7 @@ func GenerateConfigBuilder(
 		case XcodeProjectTypeIOS:
 			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.XcodeArchiveStepListItem(xcodeArchiveStepInputModels...))
 
-			if shouldAppendAppClip(hasAppClip, exportMethod) {
+			if shouldAppendExportAppClipStep(hasAppClip, exportMethod) {
 				appendExportAppClipStep(configBuilder, models.PrimaryWorkflowID)
 			}
 		case XcodeProjectTypeMacOS:
@@ -666,7 +666,7 @@ func GenerateConfigBuilder(
 			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeTestStepListItem(xcodeStepInputModels...))
 			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveStepListItem(xcodeArchiveStepInputModels...))
 
-			if shouldAppendAppClip(hasAppClip, exportMethod) {
+			if shouldAppendExportAppClipStep(hasAppClip, exportMethod) {
 				appendExportAppClipStep(configBuilder, models.DeployWorkflowID)
 			}
 		case XcodeProjectTypeMacOS:
@@ -800,7 +800,7 @@ func schemeHasAppClipTarget(scheme xcodeproj.SchemeModel, targets []xcodeproj.Ta
 	return false
 }
 
-func shouldAppendAppClip(hasAppClip bool, exportMethod string) bool {
+func shouldAppendExportAppClipStep(hasAppClip bool, exportMethod string) bool {
 	return hasAppClip &&
 		(exportMethod == "development" || exportMethod == "ad-hoc")
 }

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -808,6 +808,7 @@ func shouldAppendAppClip(hasAppClip bool, exportMethod string) bool {
 func appendExportAppClipStep(configBuilder *models.ConfigBuilderModel, workflowID models.WorkflowID) {
 	exportXCArchiveStepInputModels := []envmanModels.EnvironmentItemModel{
 		{ExportXCArchiveProductInputKey: ExportXCArchiveProductInputAppClipValue},
+		{ExportMethodInputKey: "$" + ExportMethodInputEnvKey},
 	}
 	configBuilder.AppendStepListItemsTo(workflowID, steps.ExportXCArchiveStepListItem(exportXCArchiveStepInputModels...))
 }

--- a/scanners/ios/utility_test.go
+++ b/scanners/ios/utility_test.go
@@ -3,55 +3,74 @@ package ios
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewConfigDescriptor(t *testing.T) {
-	descriptor := NewConfigDescriptor(false, "", false, true)
+	descriptor := NewConfigDescriptor(false, "", false, false, "development", true)
 	require.Equal(t, false, descriptor.HasPodfile)
 	require.Equal(t, false, descriptor.HasTest)
+	require.Equal(t, false, descriptor.HasAppClip)
+	require.Equal(t, "development", descriptor.ExportMethod)
 	require.Equal(t, true, descriptor.MissingSharedSchemes)
 	require.Equal(t, "", descriptor.CarthageCommand)
 }
 
 func TestConfigName(t *testing.T) {
-	{
-		descriptor := NewConfigDescriptor(false, "", false, false)
-		require.Equal(t, "ios-config", descriptor.ConfigName(XcodeProjectTypeIOS))
+	type testCase struct {
+		descriptor         ConfigDescriptor
+		expectedConfigName string
 	}
 
-	{
-		descriptor := NewConfigDescriptor(true, "", false, false)
-		require.Equal(t, "ios-pod-config", descriptor.ConfigName(XcodeProjectTypeIOS))
+	testCases := []testCase{
+		{
+			descriptor:         NewConfigDescriptor(false, "", false, false, "development", false),
+			expectedConfigName: "ios-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(true, "", false, false, "development", false),
+			expectedConfigName: "ios-pod-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(false, "bootsrap", false, false, "development", false),
+			expectedConfigName: "ios-carthage-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(false, "", true, false, "development", false),
+			expectedConfigName: "ios-test-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(false, "", false, false, "development", true),
+			expectedConfigName: "ios-missing-shared-schemes-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(true, "bootstrap", false, false, "development", false),
+			expectedConfigName: "ios-pod-carthage-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(true, "bootstrap", true, false, "development", false),
+			expectedConfigName: "ios-pod-carthage-test-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(true, "bootstrap", true, false, "development", true),
+			expectedConfigName: "ios-pod-carthage-test-missing-shared-schemes-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(false, "", false, true, "development", false),
+			expectedConfigName: "ios-app-clip-development-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(false, "", false, true, "ad-hoc", false),
+			expectedConfigName: "ios-app-clip-ad-hoc-config",
+		},
+		{
+			descriptor:         NewConfigDescriptor(false, "", true, true, "development", false),
+			expectedConfigName: "ios-test-app-clip-development-config",
+		},
 	}
 
-	{
-		descriptor := NewConfigDescriptor(false, "bootsrap", false, false)
-		require.Equal(t, "ios-carthage-config", descriptor.ConfigName(XcodeProjectTypeIOS))
-	}
-
-	{
-		descriptor := NewConfigDescriptor(false, "", true, false)
-		require.Equal(t, "ios-test-config", descriptor.ConfigName(XcodeProjectTypeIOS))
-	}
-
-	{
-		descriptor := NewConfigDescriptor(false, "", false, true)
-		require.Equal(t, "ios-missing-shared-schemes-config", descriptor.ConfigName(XcodeProjectTypeIOS))
-	}
-
-	{
-		descriptor := NewConfigDescriptor(true, "bootstrap", false, false)
-		require.Equal(t, "ios-pod-carthage-config", descriptor.ConfigName(XcodeProjectTypeIOS))
-	}
-
-	{
-		descriptor := NewConfigDescriptor(true, "bootstrap", true, false)
-		require.Equal(t, "ios-pod-carthage-test-config", descriptor.ConfigName(XcodeProjectTypeIOS))
-	}
-
-	{
-		descriptor := NewConfigDescriptor(true, "bootstrap", true, true)
-		require.Equal(t, "ios-pod-carthage-test-missing-shared-schemes-config", descriptor.ConfigName(XcodeProjectTypeIOS))
+	for _, testcase := range testCases {
+		assert.Equal(t, testcase.expectedConfigName, testcase.descriptor.ConfigName(XcodeProjectTypeIOS))
 	}
 }

--- a/steps/const.go
+++ b/steps/const.go
@@ -171,6 +171,14 @@ const (
 )
 
 const (
+	// ExportXCArchiveID ...
+	ExportXCArchiveID = "export-xcarchive"
+
+	// ExportXCArchiveVersion ...
+	ExportXCArchiveVersion = "3"
+)
+
+const (
 	// XcodeTestMacID ...
 	XcodeTestMacID = "xcode-test-mac"
 	// XcodeTestMacVersion ...

--- a/steps/steps.go
+++ b/steps/steps.go
@@ -204,6 +204,12 @@ func XcodeArchiveMacStepListItem(inputs ...envmanModels.EnvironmentItemModel) bi
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
+// ExportXCArchiveStepListItem ...
+func ExportXCArchiveStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(ExportXCArchiveID, ExportXCArchiveVersion)
+	return stepListItem(stepIDComposite, "", "", inputs...)
+}
+
 // XcodeTestMacStepListItem ...
 func XcodeTestMacStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(XcodeTestMacID, XcodeTestMacVersion)

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproj/xctarget_test_files.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproj/xctarget_test_files.go
@@ -1,0 +1,295 @@
+package xcodeproj
+
+const (
+	onlyApp = `
+	// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXNativeTarget section */
+		64E1835F2588FD3C00D666BF /* test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 645C5A6B2588F3F7004E3C82 /* Build configuration list for PBXNativeTarget "test" */;
+			buildPhases = (
+				645C5A532588F3F7004E3C82 /* Sources */,
+				645C5A542588F3F7004E3C82 /* Frameworks */,
+				645C5A552588F3F7004E3C82 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = test;
+			productName = test;
+			productReference = 64E1835F2588FD3C00D666BF /* test.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		645C5A4F2588F3F7004E3C82 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1220;
+				LastUpgradeCheck = 1220;
+				TargetAttributes = {
+					645C5A562588F3F7004E3C82 = {
+						CreatedOnToolsVersion = 12.2;
+					};
+				};
+			};
+			buildConfigurationList = 645C5A522588F3F7004E3C82 /* Build configuration list for PBXProject "test" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 645C5A4E2588F3F7004E3C82;
+			productRefGroup = 645C5A582588F3F7004E3C82 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				645C5A562588F3F7004E3C82 /* test */,
+			);
+		};
+/* End PBXProject section */
+	};
+	rootObject = 645C5A4F2588F3F7004E3C82 /* Project object */;
+}
+`
+
+	appWithAppClip = `
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXNativeTarget section */
+		64E1835F2588FD3C00D666BF /* test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64E1838A2588FD3D00D666BF /* Build configuration list for PBXNativeTarget "test" */;
+			buildPhases = (
+				64E1835C2588FD3C00D666BF /* Sources */,
+				64E1835D2588FD3C00D666BF /* Frameworks */,
+				64E1835E2588FD3C00D666BF /* Resources */,
+				64E183CA2588FD5F00D666BF /* Embed App Clips */,
+				64E183F22588FD9E00D666BF /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				64E183C52588FD5F00D666BF /* PBXTargetDependency */,
+			);
+			name = test;
+			productName = test;
+			productReference = 64E183602588FD3C00D666BF /* test.app */;
+			productType = "com.apple.product-type.application";
+		};
+		64E1839B2588FD5E00D666BF /* clip */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64E183C72588FD5F00D666BF /* Build configuration list for PBXNativeTarget "clip" */;
+			buildPhases = (
+				64E183982588FD5E00D666BF /* Sources */,
+				64E183992588FD5E00D666BF /* Frameworks */,
+				64E1839A2588FD5E00D666BF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = clip;
+			productName = clip;
+			productReference = 64E1839C2588FD5E00D666BF /* clip.app */;
+			productType = "com.apple.product-type.application.on-demand-install-capable";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXTargetDependency section */
+		64E183C52588FD5F00D666BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 64E1839B2588FD5E00D666BF /* clip */;
+			targetProxy = 64E183C42588FD5F00D666BF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+	};
+	rootObject = 64E183582588FD3C00D666BF /* Project object */;
+}
+`
+
+	appWithTest = `
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXNativeTarget section */
+		64E1835F2588FD3C00D666BF /* test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64E1838A2588FD3D00D666BF /* Build configuration list for PBXNativeTarget "test" */;
+			buildPhases = (
+				64E1835C2588FD3C00D666BF /* Sources */,
+				64E1835D2588FD3C00D666BF /* Frameworks */,
+				64E1835E2588FD3C00D666BF /* Resources */,
+				64E183CA2588FD5F00D666BF /* Embed App Clips */,
+				64E183F22588FD9E00D666BF /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = test;
+			productName = test;
+			productReference = 64E183602588FD3C00D666BF /* test.app */;
+			productType = "com.apple.product-type.application";
+		};
+		64E183752588FD3D00D666BF /* testTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64E1838D2588FD3D00D666BF /* Build configuration list for PBXNativeTarget "testTests" */;
+			buildPhases = (
+				64E183722588FD3D00D666BF /* Sources */,
+				64E183732588FD3D00D666BF /* Frameworks */,
+				64E183742588FD3D00D666BF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				64E183782588FD3D00D666BF /* PBXTargetDependency */,
+			);
+			name = testTests;
+			productName = testTests;
+			productReference = 64E183762588FD3D00D666BF /* testTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXTargetDependency section */
+		64E183782588FD3D00D666BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 64E1835F2588FD3C00D666BF /* test */;
+			targetProxy = 64E183772588FD3D00D666BF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+	};
+	rootObject = 64E183582588FD3C00D666BF /* Project object */;
+}
+`
+
+	appWithTestAndAppClipAndWidget = `
+	// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXNativeTarget section */
+		64E1835F2588FD3C00D666BF /* test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64E1838A2588FD3D00D666BF /* Build configuration list for PBXNativeTarget "test" */;
+			buildPhases = (
+				64E1835C2588FD3C00D666BF /* Sources */,
+				64E1835D2588FD3C00D666BF /* Frameworks */,
+				64E1835E2588FD3C00D666BF /* Resources */,
+				64E183CA2588FD5F00D666BF /* Embed App Clips */,
+				64E183F22588FD9E00D666BF /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				64E183C52588FD5F00D666BF /* PBXTargetDependency */,
+				64E183ED2588FD9E00D666BF /* PBXTargetDependency */,
+			);
+			name = test;
+			productName = test;
+			productReference = 64E183602588FD3C00D666BF /* test.app */;
+			productType = "com.apple.product-type.application";
+		};
+		64E183752588FD3D00D666BF /* testTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64E1838D2588FD3D00D666BF /* Build configuration list for PBXNativeTarget "testTests" */;
+			buildPhases = (
+				64E183722588FD3D00D666BF /* Sources */,
+				64E183732588FD3D00D666BF /* Frameworks */,
+				64E183742588FD3D00D666BF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				64E183782588FD3D00D666BF /* PBXTargetDependency */,
+			);
+			name = testTests;
+			productName = testTests;
+			productReference = 64E183762588FD3D00D666BF /* testTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		64E1839B2588FD5E00D666BF /* clip */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64E183C72588FD5F00D666BF /* Build configuration list for PBXNativeTarget "clip" */;
+			buildPhases = (
+				64E183982588FD5E00D666BF /* Sources */,
+				64E183992588FD5E00D666BF /* Frameworks */,
+				64E1839A2588FD5E00D666BF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = clip;
+			productName = clip;
+			productReference = 64E1839C2588FD5E00D666BF /* clip.app */;
+			productType = "com.apple.product-type.application.on-demand-install-capable";
+		};
+		64E183DC2588FD9D00D666BF /* widgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64E183EF2588FD9E00D666BF /* Build configuration list for PBXNativeTarget "widgetExtension" */;
+			buildPhases = (
+				64E183D92588FD9D00D666BF /* Sources */,
+				64E183DA2588FD9D00D666BF /* Frameworks */,
+				64E183DB2588FD9D00D666BF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = widgetExtension;
+			productName = widgetExtension;
+			productReference = 64E183DD2588FD9D00D666BF /* widgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXTargetDependency section */
+		64E183782588FD3D00D666BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 64E1835F2588FD3C00D666BF /* test */;
+			targetProxy = 64E183772588FD3D00D666BF /* PBXContainerItemProxy */;
+		};
+		64E183C52588FD5F00D666BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 64E1839B2588FD5E00D666BF /* clip */;
+			targetProxy = 64E183C42588FD5F00D666BF /* PBXContainerItemProxy */;
+		};
+		64E183ED2588FD9E00D666BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 64E183DC2588FD9D00D666BF /* widgetExtension */;
+			targetProxy = 64E183EC2588FD9E00D666BF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+	};
+	rootObject = 64E183582588FD3C00D666BF /* Project object */;
+}
+`
+)


### PR DESCRIPTION
## Context
Add support for AppClips in ProjectScanner. If AppClip is detected the generated workflow contains a step to export it along the app.

[STEP-87](https://bitrise.atlassian.net/browse/STEP-87)

## File to check
- Do *NOT* check `/vendor` folder

## Changes
- Add export appclip step where applicable.
- Added new test case (`sample-apps-appclip`) to `ios_test.go` and refectored to table tests.

## Investigation details
- Exporting appclip is only applicable for `development` and `ad-hoc` export methods.
