### PR TITLE
Improve cocoapods workspace detection

### DIFF
--- a/_tests/integration/reactnative_expo_test.go
+++ b/_tests/integration/reactnative_expo_test.go
@@ -538,14 +538,5 @@ configs:
 warnings:
   react-native: []
 warnings_with_recommendations:
-  react-native:
-  - error: 'Failed to determine cocoapods project-workspace mapping, error: failed
-      to get user defined project path, error: failed to get target definition map,
-      error: failed to read target defintion map, error: Pod::DSLError'
-    recommendations:
-      DetailedError:
-        title: We couldn’t parse your project files.
-        description: |-
-          You can fix the problem and try again, or skip auto-configuration and set up your project manually. Our auto-configurator returned the following error:
-          Failed to determine cocoapods project-workspace mapping, error: failed to get user defined project path, error: failed to get target definition map, error: failed to read target defintion map, error: Pod::DSLError
+  react-native: []
 `, sampleAppsExpoBareVersions...)

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -33,6 +33,8 @@ func stacks() []string {
 		"osx-xcode-12.1.x",
 		"osx-xcode-12.2.x",
 		"osx-xcode-12.3.x",
+		"osx-xcode-12.4.x",
+		"osx-xcode-12.5.x",
 		"osx-xcode-9.4.x",
 		"osx-xcode-edge",
 	}

--- a/scanners/ios/ios.go
+++ b/scanners/ios/ios.go
@@ -8,9 +8,10 @@ import "github.com/bitrise-io/bitrise-init/models"
 
 // Scanner ...
 type Scanner struct {
-	SearchDir         string
-	ConfigDescriptors []ConfigDescriptor
-	ExcludeAppIcon    bool
+	SearchDir                 string
+	ConfigDescriptors         []ConfigDescriptor
+	ExcludeAppIcon            bool
+	SuppressPodFileParseError bool
 }
 
 // NewScanner ...
@@ -42,7 +43,7 @@ func (Scanner) ExcludedScannerNames() []string {
 
 // Options ...
 func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, error) {
-	options, configDescriptors, icons, warnings, err := GenerateOptions(XcodeProjectTypeIOS, scanner.SearchDir, scanner.ExcludeAppIcon)
+	options, configDescriptors, icons, warnings, err := GenerateOptions(XcodeProjectTypeIOS, scanner.SearchDir, scanner.ExcludeAppIcon, scanner.SuppressPodFileParseError)
 	if err != nil {
 		return models.OptionNode{}, warnings, nil, err
 	}

--- a/scanners/ios/podfile.go
+++ b/scanners/ios/podfile.go
@@ -26,7 +26,8 @@ func getTargetDefinitionProjectMap(podfilePth, cocoapodsVersion string) (map[str
 	}
 
 	gemfileContent := fmt.Sprintf(`source 'https://rubygems.org'
-gem 'cocoapods-core'%s
+gem 'cocoapods'%s
+gem 'cocoapods-core'
 gem 'json'
 `, gemfileCocoapodsVersion)
 
@@ -37,6 +38,9 @@ require 'json'
 
 begin
 	podfile_path = ENV['PODFILE_PATH']
+	# In case of relative require in the Podfile, change working directory
+	# For example: require_relative '../node_modules/react-native/scripts/react_native_pods'
+	Dir.chdir(File.dirname(podfile_path))
 	podfile = Pod::Podfile.from_file(podfile_path)
 	targets = podfile.target_definitions
 	
@@ -50,7 +54,7 @@ begin
 
 	puts "#{{ :data => target_project_map }.to_json}"
 rescue => e
-	puts "#{{ :error => e.to_s }.to_json}"
+	puts "#{{ :error => "#{e.to_s} Reason: #{e.message}"}.to_json}"
 end
 `
 
@@ -109,7 +113,8 @@ func getUserDefinedWorkspaceRelativePath(podfilePth, cocoapodsVersion string) (s
 	}
 
 	gemfileContent := fmt.Sprintf(`source 'https://rubygems.org'
-gem 'cocoapods-core'%s
+gem 'cocoapods'%s
+gem 'cocoapods-core'
 gem 'json'
 `, gemfileCocoapodsVersion)
 
@@ -120,11 +125,14 @@ require 'json'
 
 begin
 	podfile_path = ENV['PODFILE_PATH']
+	# In case of relative require in the Podfile, change working directory
+	# For example: require_relative '../node_modules/react-native/scripts/react_native_pods'
+	Dir.chdir(File.dirname(podfile_path))
 	podfile = Pod::Podfile.from_file(podfile_path)
 	pth = podfile.workspace_path
 	puts "#{{ :data => pth }.to_json}"
 rescue => e
-	puts "#{{ :error => e.to_s }.to_json}"
+	puts "#{{ :error => "#{e.to_s} Reason: #{e.message}"}.to_json}"
 end
 `
 	absPodfilePth, err := filepath.Abs(podfilePth)
@@ -155,7 +163,7 @@ end
 	}
 
 	if workspacePathOutput.Error != "" {
-		return "", fmt.Errorf("failed to readworkspace path, error: %s", workspacePathOutput.Error)
+		return "", fmt.Errorf("failed to read workspace path, error: %s", workspacePathOutput.Error)
 	}
 
 	return workspacePathOutput.Data, nil

--- a/scanners/ios/podfile_test.go
+++ b/scanners/ios/podfile_test.go
@@ -79,11 +79,13 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		expectedTargetDefinition := map[string]string{
 			"Pods": "MyXcodeProject.xcodeproj",
 		}
-		actualTargetDefinition, err := getTargetDefinitionProjectMap(podfilePth, "")
+
+		actualTargetDefinition, err := podparser.getTargetDefinitionProjectMap("")
 		require.NoError(t, err)
 		require.Equal(t, expectedTargetDefinition, actualTargetDefinition)
 	}
@@ -98,9 +100,10 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		expectedTargetDefinition := map[string]string{}
-		actualTargetDefinition, err := getTargetDefinitionProjectMap(podfilePth, "")
+		actualTargetDefinition, err := podparser.getTargetDefinitionProjectMap("")
 		require.NoError(t, err)
 		require.Equal(t, expectedTargetDefinition, actualTargetDefinition)
 	}
@@ -129,9 +132,10 @@ end
 # end`
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		expectedTargetDefinition := map[string]string{}
-		actualTargetDefinition, err := getTargetDefinitionProjectMap(podfilePth, "0.38.0")
+		actualTargetDefinition, err := podparser.getTargetDefinitionProjectMap("0.38.0")
 		require.NoError(t, err)
 		require.Equal(t, expectedTargetDefinition, actualTargetDefinition)
 	}
@@ -155,9 +159,10 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		expectedProject := "MyXcodeProject.xcodeproj"
-		actualProject, err := getUserDefinedProjectRelavtivePath(podfilePth, "")
+		actualProject, err := podparser.getUserDefinedProjectRelavtivePath("")
 		require.NoError(t, err)
 		require.Equal(t, expectedProject, actualProject)
 	}
@@ -172,9 +177,10 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		expectedProject := ""
-		actualProject, err := getUserDefinedProjectRelavtivePath(podfilePth, "")
+		actualProject, err := podparser.getUserDefinedProjectRelavtivePath("")
 		require.NoError(t, err)
 		require.Equal(t, expectedProject, actualProject)
 	}
@@ -198,9 +204,10 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		expectedWorkspace := "MyWorkspace.xcworkspace"
-		actualWorkspace, err := getUserDefinedWorkspaceRelativePath(podfilePth, "")
+		actualWorkspace, err := podparser.getUserDefinedWorkspaceRelativePath("")
 		require.NoError(t, err)
 		require.Equal(t, expectedWorkspace, actualWorkspace)
 	}
@@ -215,9 +222,10 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		expectedWorkspace := ""
-		actualWorkspace, err := getUserDefinedWorkspaceRelativePath(podfilePth, "")
+		actualWorkspace, err := podparser.getUserDefinedWorkspaceRelativePath("")
 		require.NoError(t, err)
 		require.Equal(t, expectedWorkspace, actualWorkspace)
 	}
@@ -240,8 +248,9 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfilePth, []string{})
+		workspaceProjectMap, err := podparser.GetWorkspaceProjectMap([]string{})
 		require.Error(t, err)
 		require.Equal(t, 0, len(workspaceProjectMap))
 
@@ -258,12 +267,13 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		project := ""
 		projectPth := filepath.Join(tmpDir, "project.xcodeproj")
 		require.NoError(t, fileutil.WriteStringToFile(projectPth, project))
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfilePth, []string{projectPth})
+		workspaceProjectMap, err := podparser.GetWorkspaceProjectMap([]string{projectPth})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(workspaceProjectMap))
 
@@ -291,6 +301,7 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		project1 := ""
 		project1Pth := filepath.Join(tmpDir, "project1.xcodeproj")
@@ -300,7 +311,7 @@ pod 'Alamofire', '~> 3.4'
 		project2Pth := filepath.Join(tmpDir, "project2.xcodeproj")
 		require.NoError(t, fileutil.WriteStringToFile(project2Pth, project2))
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfilePth, []string{project1Pth, project2Pth})
+		workspaceProjectMap, err := podparser.GetWorkspaceProjectMap([]string{project1Pth, project2Pth})
 		require.Error(t, err)
 		require.Equal(t, 0, len(workspaceProjectMap))
 
@@ -318,8 +329,9 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfilePth, []string{})
+		workspaceProjectMap, err := podparser.GetWorkspaceProjectMap([]string{})
 		require.Error(t, err)
 		require.Equal(t, 0, len(workspaceProjectMap))
 
@@ -337,12 +349,13 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		project := ""
 		projectPth := filepath.Join(tmpDir, "project.xcodeproj")
 		require.NoError(t, fileutil.WriteStringToFile(projectPth, project))
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfilePth, []string{projectPth})
+		workspaceProjectMap, err := podparser.GetWorkspaceProjectMap([]string{projectPth})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(workspaceProjectMap))
 
@@ -371,6 +384,7 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		project1 := ""
 		project1Pth := filepath.Join(tmpDir, "project1.xcodeproj")
@@ -380,7 +394,7 @@ pod 'Alamofire', '~> 3.4'
 		project2Pth := filepath.Join(tmpDir, "project2.xcodeproj")
 		require.NoError(t, fileutil.WriteStringToFile(project2Pth, project2))
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfilePth, []string{project1Pth, project2Pth})
+		workspaceProjectMap, err := podparser.GetWorkspaceProjectMap([]string{project1Pth, project2Pth})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(workspaceProjectMap))
 
@@ -409,12 +423,13 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		project := ""
 		projectPth := filepath.Join(tmpDir, "project.xcodeproj")
 		require.NoError(t, fileutil.WriteStringToFile(projectPth, project))
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfilePth, []string{projectPth})
+		workspaceProjectMap, err := podparser.GetWorkspaceProjectMap([]string{projectPth})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(workspaceProjectMap))
 
@@ -444,6 +459,7 @@ pod 'Alamofire', '~> 3.4'
 `
 		podfilePth := filepath.Join(tmpDir, "Podfile")
 		require.NoError(t, fileutil.WriteStringToFile(podfilePth, podfile))
+		podparser := podfileParser{podfilePth: podfilePth}
 
 		project1 := ""
 		project1Pth := filepath.Join(tmpDir, "project1.xcodeproj")
@@ -453,7 +469,7 @@ pod 'Alamofire', '~> 3.4'
 		project2Pth := filepath.Join(tmpDir, "project2.xcodeproj")
 		require.NoError(t, fileutil.WriteStringToFile(project2Pth, project2))
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfilePth, []string{project1Pth, project2Pth})
+		workspaceProjectMap, err := podparser.GetWorkspaceProjectMap([]string{project1Pth, project2Pth})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(workspaceProjectMap))
 
@@ -506,7 +522,8 @@ func TestMergePodWorkspaceProjectMap(t *testing.T) {
 			},
 		}
 
-		mergedStandaloneProjects, mergedWorkspaces, err := MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
+		podparser := podfileParser{podfilePth: ""}
+		mergedStandaloneProjects, mergedWorkspaces, err := podparser.MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
 		require.NoError(t, err)
 		require.Equal(t, expectedStandaloneProjects, mergedStandaloneProjects)
 		require.Equal(t, expectedWorkspaces, mergedWorkspaces)
@@ -527,7 +544,8 @@ func TestMergePodWorkspaceProjectMap(t *testing.T) {
 			},
 		}
 
-		mergedStandaloneProjects, mergedWorkspaces, err := MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
+		podparser := podfileParser{podfilePth: ""}
+		mergedStandaloneProjects, mergedWorkspaces, err := podparser.MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
 		require.Error(t, err)
 		require.Equal(t, []xcodeproj.ProjectModel{}, mergedStandaloneProjects)
 		require.Equal(t, []xcodeproj.WorkspaceModel{}, mergedWorkspaces)
@@ -552,7 +570,8 @@ func TestMergePodWorkspaceProjectMap(t *testing.T) {
 			},
 		}
 
-		mergedStandaloneProjects, mergedWorkspaces, err := MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
+		podparser := podfileParser{podfilePth: ""}
+		mergedStandaloneProjects, mergedWorkspaces, err := podparser.MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
 		require.Error(t, err)
 		require.Equal(t, []xcodeproj.ProjectModel{}, mergedStandaloneProjects)
 		require.Equal(t, []xcodeproj.WorkspaceModel{}, mergedWorkspaces)
@@ -585,7 +604,8 @@ func TestMergePodWorkspaceProjectMap(t *testing.T) {
 			},
 		}
 
-		mergedStandaloneProjects, mergedWorkspaces, err := MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
+		podparser := podfileParser{podfilePth: ""}
+		mergedStandaloneProjects, mergedWorkspaces, err := podparser.MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
 		require.NoError(t, err)
 		require.Equal(t, expectedStandaloneProjects, mergedStandaloneProjects)
 		require.Equal(t, expectedWorkspaces, mergedWorkspaces)
@@ -601,7 +621,8 @@ func TestMergePodWorkspaceProjectMap(t *testing.T) {
 
 		workspaces := []xcodeproj.WorkspaceModel{}
 
-		mergedStandaloneProjects, mergedWorkspaces, err := MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
+		podparser := podfileParser{podfilePth: ""}
+		mergedStandaloneProjects, mergedWorkspaces, err := podparser.MergePodWorkspaceProjectMap(podWorkspaceMap, standaloneProjects, workspaces)
 		require.Error(t, err)
 		require.Equal(t, []xcodeproj.ProjectModel{}, mergedStandaloneProjects)
 		require.Equal(t, []xcodeproj.WorkspaceModel{}, mergedWorkspaces)

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -259,7 +259,7 @@ func projectPathByScheme(projects []xcodeproj.ProjectModel, targetScheme string)
 }
 
 // GenerateOptions ...
-func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppIcon bool) (models.OptionNode, []ConfigDescriptor, models.Icons, models.Warnings, error) {
+func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppIcon, suppressPodFileParseError bool) (models.OptionNode, []ConfigDescriptor, models.Icons, models.Warnings, error) {
 	warnings := models.Warnings{}
 
 	fileList, err := utility.ListPathInDirSortedByComponents(searchDir, true)
@@ -309,7 +309,12 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 	for _, podfile := range podfiles {
 		log.TPrintf("- %s", podfile)
 
-		workspaceProjectMap, err := GetWorkspaceProjectMap(podfile, projectFiles)
+		podfileParser := podfileParser{
+			podfilePth:                podfile,
+			suppressPodFileParseError: suppressPodFileParseError,
+		}
+
+		workspaceProjectMap, err := podfileParser.GetWorkspaceProjectMap(projectFiles)
 		if err != nil {
 			warning := fmt.Sprintf("Failed to determine cocoapods project-workspace mapping, error: %s", err)
 			warnings = append(warnings, warning)
@@ -317,7 +322,7 @@ func GenerateOptions(projectType XcodeProjectType, searchDir string, excludeAppI
 			continue
 		}
 
-		aStandaloneProjects, aWorkspaces, err := MergePodWorkspaceProjectMap(workspaceProjectMap, standaloneProjects, workspaces)
+		aStandaloneProjects, aWorkspaces, err := podfileParser.MergePodWorkspaceProjectMap(workspaceProjectMap, standaloneProjects, workspaces)
 		if err != nil {
 			warning := fmt.Sprintf("Failed to create cocoapods project-workspace mapping, error: %s", err)
 			warnings = append(warnings, warning)

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -44,7 +44,7 @@ func (Scanner) ExcludedScannerNames() []string {
 
 // Options ...
 func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, error) {
-	options, configDescriptors, _, warnings, err := ios.GenerateOptions(ios.XcodeProjectTypeMacOS, scanner.searchDir, true)
+	options, configDescriptors, _, warnings, err := ios.GenerateOptions(ios.XcodeProjectTypeMacOS, scanner.searchDir, true, false)
 	if err != nil {
 		return models.OptionNode{}, warnings, nil, err
 	}

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -72,6 +72,7 @@ func (scanner *Scanner) options() (models.OptionNode, models.Warnings, error) {
 		if detected, err := scanner.iosScanner.DetectPlatform(scanner.searchDir); err != nil {
 			return models.OptionNode{}, warnings, err
 		} else if detected {
+			scanner.iosScanner.SuppressPodFileParseError = true
 			options, warns, _, err := scanner.iosScanner.Options()
 			warnings = append(warnings, warns...)
 			if err != nil {


### PR DESCRIPTION
When using react-native, it includes a relative path from node_modules (require_relative '../node_modules/react-native/scripts/react_native_pods').
Fixed the case when node_modules is present. Can not support the case if it is not.

Added 'cocoapods' dependency in the Gemfile, as cocoapods-core is not enough in itself.
Log the reason when can not parse Podfile.