### PR TITLE
Adds Log Statements to Android Project Scanner

### DIFF
--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-init/analytics"
 	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/go-utils/log"
 )
 
 // Scanner ...
@@ -42,12 +43,22 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (_ bool, err error) {
 		{"settings.gradle", "settings.gradle.kts"},
 	}
 	skipDirs := []string{".git", "CordovaLib", "node_modules"}
+
+	log.TInfof("Searching for android files")
+
 	scanner.ProjectRoots, err = walkMultipleFileGroups(searchDir, projectFiles, skipDirs)
 	if err != nil {
 		return false, fmt.Errorf("failed to search for build.gradle files, error: %s", err)
 	}
 
-	return len(scanner.ProjectRoots) > 0, err
+	log.TSuccessf("Platform detected")
+
+	for _, file := range projectFiles {
+		log.TPrintf("- %s", file)
+	}
+	countDetected := len(scanner.ProjectRoots) > 0
+	log.TPrintf("%d android files detected", countDetected)
+	return countDetected, err
 }
 
 // Options ...

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -56,9 +56,10 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (_ bool, err error) {
 	for _, file := range projectFiles {
 		log.TPrintf("- %s", file)
 	}
-	countDetected := len(scanner.ProjectRoots) > 0
+	countDetected := len(scanner.ProjectRoots)
 	log.TPrintf("%d android files detected", countDetected)
-	return countDetected, err
+	nonZeroCount := countDetected > 0
+	return nonZeroCount, err
 }
 
 // Options ...


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/82456480/126344506-12abf2ae-93f0-4660-872c-e02f55fa8800.png)

I was troubleshooting the project scanner, and it was unclear to me if the android project scanner found any files. This PR adds some log statements to make this easier to quickly get info.