### PR TITLE
Bump Xcode Test for iOS step to 3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _bin/
 .gows*
 bitrise-init
 .vscode/
+.idea/

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -28,6 +28,7 @@ func stacks() []string {
 		"osx-xcode-12.3.x",
 		"osx-xcode-12.4.x",
 		"osx-xcode-12.5.x",
+		"osx-xcode-13.0.x",
 		"osx-xcode-edge",
 	}
 }
@@ -48,7 +49,7 @@ func (reports systemReports) Stacks() (s []string) {
 func TestStackChange(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/bitrise-io/bitrise.io/contents/system_reports", nil)
 	if err != nil {
-		t.Fatalf("setup: faile to create request: %s", err)
+		t.Fatalf("setup: failed to create request: %s", err)
 	}
 
 	token := os.Getenv("GIT_BOT_USER_ACCESS_TOKEN")

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -78,6 +78,6 @@ func TestStackChange(t *testing.T) {
 	}
 
 	if expected := reports.Stacks(); !reflect.DeepEqual(expected, stacks()) {
-		t.Fatalf("Stack list changed, current: %v, expecting: %v", stacks(), expected)
+		t.Fatalf("Stack list changed, current: %v, expecting: %v", expected, stacks())
 	}
 }

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -77,7 +77,7 @@ func TestStackChange(t *testing.T) {
 		t.Fatalf("Error unmarshalling stack data from string (%s): %s", bytes, err)
 	}
 
-	if expected := reports.Stacks(); !reflect.DeepEqual(expected, stacks()) {
-		t.Fatalf("Stack list changed, current: %v, expecting: %v", expected, stacks())
+	if currentStacks := reports.Stacks(); !reflect.DeepEqual(currentStacks, stacks()) {
+		t.Fatalf("Stack list changed, current: %v, expecting: %v", currentStacks, stacks())
 	}
 }

--- a/steps/const.go
+++ b/steps/const.go
@@ -132,7 +132,7 @@ const (
 	// XcodeTestID ...
 	XcodeTestID = "xcode-test"
 	// XcodeTestVersion ...
-	XcodeTestVersion = "2"
+	XcodeTestVersion = "3"
 )
 
 const (

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION ...
-const VERSION = "2.5.1"
+const VERSION = "2.6.0"


### PR DESCRIPTION
## Changes
**Bump Xcode Test for iOS step to 3.0.0**
* Cleaned up test error messages regarding stacks.