### PR TITLE
Do not specify module in Android Lint and Android Unit Test

### DIFF
--- a/_tests/integration/android_test.go
+++ b/_tests/integration/android_test.go
@@ -240,12 +240,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-build@%s:
               inputs:
@@ -270,12 +268,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
@@ -428,12 +424,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-build@%s:
               inputs:
@@ -458,12 +452,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
@@ -589,12 +581,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-build@%s:
               inputs:
@@ -619,12 +609,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
@@ -725,12 +713,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-build@%s:
               inputs:
@@ -755,12 +741,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1094,12 +1094,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-build@%s:
               inputs:
@@ -1124,12 +1122,10 @@ configs:
           - android-lint@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-              - module: $MODULE
               - variant: $VARIANT
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -16,7 +16,6 @@ type fileGroups [][]string
 var pathUtilIsPathExists = pathutil.IsPathExists
 var filePathWalk = filepath.Walk
 
-// Constants ...
 const (
 	ScannerName       = "android"
 	ConfigName        = "android-config"
@@ -39,9 +38,7 @@ const (
 	ModuleInputTitle   = "Module"
 	ModuleInputSummary = "Modules provide a container for your Android project's source code, resource files, and app level settings, such as the module-level build file and Android manifest file. Each module can be independently built, tested, and debugged. You can add new modules to your Bitrise builds at any time."
 
-	GradlewPathInputKey    = "gradlew_path"
-	GradlewPathInputEnvKey = "GRADLEW_PATH"
-	GradlewPathInputTitle  = "Gradlew file path"
+	GradlewPathInputKey = "gradlew_path"
 )
 
 func walk(src string, fn func(path string, info os.FileInfo) error) error {

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -16,6 +16,7 @@ type fileGroups [][]string
 var pathUtilIsPathExists = pathutil.IsPathExists
 var filePathWalk = filepath.Walk
 
+// Constants ...
 const (
 	ScannerName       = "android"
 	ConfigName        = "android-config"

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -148,18 +148,12 @@ func (scanner *Scanner) generateConfigBuilder() models.ConfigBuilderModel {
 			ProjectLocationInputKey: projectLocationEnv,
 		},
 		envmanModels.EnvironmentItemModel{
-			ModuleInputKey: moduleEnv,
-		},
-		envmanModels.EnvironmentItemModel{
 			VariantInputKey: variantEnv,
 		},
 	))
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.AndroidUnitTestStepListItem(
 		envmanModels.EnvironmentItemModel{
 			ProjectLocationInputKey: projectLocationEnv,
-		},
-		envmanModels.EnvironmentItemModel{
-			ModuleInputKey: moduleEnv,
 		},
 		envmanModels.EnvironmentItemModel{
 			VariantInputKey: variantEnv,
@@ -182,18 +176,12 @@ func (scanner *Scanner) generateConfigBuilder() models.ConfigBuilderModel {
 			ProjectLocationInputKey: projectLocationEnv,
 		},
 		envmanModels.EnvironmentItemModel{
-			ModuleInputKey: moduleEnv,
-		},
-		envmanModels.EnvironmentItemModel{
 			VariantInputKey: variantEnv,
 		},
 	))
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.AndroidUnitTestStepListItem(
 		envmanModels.EnvironmentItemModel{
 			ProjectLocationInputKey: projectLocationEnv,
-		},
-		envmanModels.EnvironmentItemModel{
-			ModuleInputKey: moduleEnv,
 		},
 		envmanModels.EnvironmentItemModel{
 			VariantInputKey: variantEnv,

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION ...
-const VERSION = "2.8.0"
+const VERSION = "2.9.0"


### PR DESCRIPTION
## Context
* When a new Android app is added to Bitrise, we create default workflows for the user: `primary` and `deploy`.
* In these workflows we use the Android Lint and Android Unit Test steps, where the `Module` input is set to `$MODULE`. This means tests and lint checks will only be performed against the module that was specified by the user when the project's Bitrise config was generated (e.g. when the app was added to Bitrise).
* In multi-module Android projects, unit tests and lint issues can be in multiple modules, not just in the one that was initially provided by the user.
* Therefore, it doesn't make much sense to run lint checks and unit tests only in that module by default.

## Changes
* Do not specify any modules in the generated workflows' Android Lint and Android Unit Test steps.