### PR TITLE
[STEP-1750 & STEP-1749] Update iOS default workflows

### DIFF
--- a/_tests/integration/android_test.go
+++ b/_tests/integration/android_test.go
@@ -196,8 +196,7 @@ configs:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html) for signing and deployment options.
             - [Set up code signing with *Android Sign* Step](https://devcenter.bitrise.io/en/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -230,8 +229,7 @@ configs:
             Next steps:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -348,8 +346,7 @@ configs:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html) for signing and deployment options.
             - [Set up code signing with *Android Sign* Step](https://devcenter.bitrise.io/en/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -382,8 +379,7 @@ configs:
             Next steps:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -473,8 +469,7 @@ configs:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html) for signing and deployment options.
             - [Set up code signing with *Android Sign* Step](https://devcenter.bitrise.io/en/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -507,8 +502,7 @@ configs:
             Next steps:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -576,8 +570,7 @@ configs:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html) for signing and deployment options.
             - [Set up code signing with *Android Sign* Step](https://devcenter.bitrise.io/en/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -610,8 +603,7 @@ configs:
             Next steps:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -175,9 +175,13 @@ configs:
           - cache-pull@%s: {}
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -194,6 +198,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -178,6 +178,7 @@ configs:
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -51,21 +51,17 @@ var fastlaneVersions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var fastlaneResultYML = fmt.Sprintf(`options:
@@ -165,40 +161,41 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - deploy-to-bitrise-io@%s: {}
+              - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   fastlane: []
   ios: []

--- a/_tests/integration/helper.go
+++ b/_tests/integration/helper.go
@@ -40,13 +40,13 @@ func replaceVersions(str string, versions ...interface{}) (string, error) {
 
 func validateConfigExpectation(t *testing.T, ID, expected, actual string, versions ...interface{}) {
 	if !assert.ObjectsAreEqual(expected, actual) {
-		s, err := replaceVersions(actual, versions...)
-		require.NoError(t, err)
-		fmt.Println("---------------------")
-		fmt.Println("Actual config format:")
-		fmt.Println("---------------------")
-		fmt.Println(s)
-		fmt.Println("---------------------")
+		_, err := replaceVersions(actual, versions...)
+		//require.NoError(t, err)
+		//fmt.Println("---------------------")
+		//fmt.Println("Actual config format:")
+		//fmt.Println("---------------------")
+		//fmt.Println(s)
+		//fmt.Println("---------------------")
 
 		_, err = exec.LookPath("opendiff")
 		if err == nil {

--- a/_tests/integration/helper.go
+++ b/_tests/integration/helper.go
@@ -40,13 +40,13 @@ func replaceVersions(str string, versions ...interface{}) (string, error) {
 
 func validateConfigExpectation(t *testing.T, ID, expected, actual string, versions ...interface{}) {
 	if !assert.ObjectsAreEqual(expected, actual) {
-		_, err := replaceVersions(actual, versions...)
-		//require.NoError(t, err)
-		//fmt.Println("---------------------")
-		//fmt.Println("Actual config format:")
-		//fmt.Println("---------------------")
-		//fmt.Println(s)
-		//fmt.Println("---------------------")
+		s, err := replaceVersions(actual, versions...)
+		require.NoError(t, err)
+		fmt.Println("---------------------")
+		fmt.Println("Actual config format:")
+		fmt.Println("---------------------")
+		fmt.Println(s)
+		fmt.Println("---------------------")
 
 		_, err = exec.LookPath("opendiff")
 		if err == nil {

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -151,12 +151,18 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - recreate-user-schemes@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -171,9 +177,13 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - recreate-user-schemes@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -278,9 +288,13 @@ configs:
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -298,6 +312,8 @@ configs:
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -470,6 +486,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -486,6 +504,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -514,9 +534,13 @@ configs:
           - cache-pull@%s: {}
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -533,6 +557,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -627,9 +653,13 @@ configs:
               - carthage_command: bootstrap
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -649,6 +679,8 @@ configs:
               - carthage_command: bootstrap
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -720,10 +752,14 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - export-xcarchive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - product: app-clip
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
@@ -741,6 +777,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -769,6 +807,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -785,6 +825,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -813,10 +855,14 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - export-xcarchive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - product: app-clip
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
@@ -834,6 +880,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -862,6 +910,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -878,6 +928,8 @@ configs:
           - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -76,23 +76,19 @@ var iosNoSharedSchemesVersions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.XcodeTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var iosNoSharedSchemesResultYML = fmt.Sprintf(`options:
@@ -143,46 +139,43 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
-          - recreate-user-schemes@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
+          - recreate-user-schemes@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
-          - recreate-user-schemes@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
+          - recreate-user-schemes@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - deploy-to-bitrise-io@%s: {}
+              - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
 warnings_with_recommendations:
@@ -206,23 +199,19 @@ var iosCocoapodsAtRootVersions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var iosCocoapodsAtRootResultYML = fmt.Sprintf(`options:
@@ -273,42 +262,43 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - deploy-to-bitrise-io@%s: {}
+              - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
 warnings_with_recommendations:
@@ -320,31 +310,32 @@ var sampleAppsIosWatchkitVersions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
+
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CachePullVersion,
+	steps.XcodeBuildForTestVersion,
+	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var sampleAppsIosWatchkitResultYML = fmt.Sprintf(`options:
@@ -462,22 +453,39 @@ configs:
       - pull_request_source_branch: '*'
         workflow: primary
       workflows:
-        primary:
+        deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
+        primary:
+          description: |
+            The workflow only builds the project because the project scanner could not find any tests.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - cache-pull@%s: {}
+          - xcode-build-for-test@%s:
+              inputs:
+              - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+          - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     ios-test-config: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -489,40 +497,41 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - deploy-to-bitrise-io@%s: {}
+              - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
 warnings_with_recommendations:
@@ -534,23 +543,19 @@ var sampleAppsCarthageVersions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.CarthageVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.CarthageVersion,
 	steps.XcodeTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var sampleAppsCarthageResultYML = fmt.Sprintf(`options:
@@ -601,46 +606,47 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - carthage@%s:
               inputs:
               - carthage_command: bootstrap
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - carthage@%s:
               inputs:
               - carthage_command: bootstrap
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - deploy-to-bitrise-io@%s: {}
+              - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
 warnings_with_recommendations:
@@ -694,26 +700,43 @@ configs:
       - pull_request_source_branch: '*'
         workflow: primary
       workflows:
-        primary:
+        deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
+              - automatic_code_signing: api-key
           - export-xcarchive@%s:
               inputs:
               - product: app-clip
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
+        primary:
+          description: |
+            The workflow only builds the project because the project scanner could not find any tests.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - cache-pull@%s: {}
+          - xcode-build-for-test@%s:
+              inputs:
+              - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+          - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     ios-app-clip-app-store-config: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -724,22 +747,39 @@ configs:
       - pull_request_source_branch: '*'
         workflow: primary
       workflows:
-        primary:
+        deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
+        primary:
+          description: |
+            The workflow only builds the project because the project scanner could not find any tests.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - cache-pull@%s: {}
+          - xcode-build-for-test@%s:
+              inputs:
+              - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+          - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     ios-app-clip-development-config: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -750,26 +790,43 @@ configs:
       - pull_request_source_branch: '*'
         workflow: primary
       workflows:
-        primary:
+        deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
+              - automatic_code_signing: api-key
           - export-xcarchive@%s:
               inputs:
               - product: app-clip
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
+        primary:
+          description: |
+            The workflow only builds the project because the project scanner could not find any tests.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - cache-pull@%s: {}
+          - xcode-build-for-test@%s:
+              inputs:
+              - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+          - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     ios-app-clip-enterprise-config: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -780,69 +837,110 @@ configs:
       - pull_request_source_branch: '*'
         workflow: primary
       workflows:
-        primary:
+        deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
+        primary:
+          description: |
+            The workflow only builds the project because the project scanner could not find any tests.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - cache-pull@%s: {}
+          - xcode-build-for-test@%s:
+              inputs:
+              - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+          - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
 warnings_with_recommendations:
   ios: []`,
-	// ios-app-clip-ad-hoc-config/primary
+	// ios-app-clip-ad-hoc-config/deploy
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeArchiveVersion,
 	steps.ExportXCArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// ios-app-clip-ad-hoc-config/primary
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CachePullVersion,
+	steps.XcodeBuildForTestVersion,
+	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// ios-app-clip-app-store-config/deploy
+	models.FormatVersion,
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CachePullVersion,
+	steps.XcodeArchiveVersion,
+	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// ios-app-clip-app-store-config/primary
-	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
+	steps.XcodeBuildForTestVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
-	// ios-app-clip-development-config/primary
+	// ios-app-clip-development-config/deploy
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeArchiveVersion,
 	steps.ExportXCArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
-	// ios-app-clip-enterprise-config/primary
+	// ios-app-clip-development-config/primary
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CachePullVersion,
+	steps.XcodeBuildForTestVersion,
+	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// ios-app-clip-enterprise-config/deploy
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// ios-app-clip-enterprise-config/primary
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CachePullVersion,
+	steps.XcodeBuildForTestVersion,
+	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 )

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -157,6 +157,7 @@ configs:
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -280,6 +281,7 @@ configs:
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -468,6 +470,7 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -514,6 +517,7 @@ configs:
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -626,6 +630,7 @@ configs:
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -715,10 +720,12 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - export-xcarchive@%s:
               inputs:
               - product: app-clip
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -762,6 +769,7 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -805,10 +813,12 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - export-xcarchive@%s:
               inputs:
               - product: app-clip
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -852,6 +862,7 @@ configs:
           - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}

--- a/_tests/integration/mac_test.go
+++ b/_tests/integration/mac_test.go
@@ -41,21 +41,18 @@ var sampleAppsOSX1011Versions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeTestMacVersion,
 	steps.XcodeArchiveMacVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeTestMacVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var sampleAppsOSX1011ResultYML = fmt.Sprintf(`options:
@@ -109,12 +106,9 @@ configs:
       workflows:
         deploy:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - xcode-test-mac@%s:
               inputs:
@@ -125,23 +119,16 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - export_method: $BITRISE_EXPORT_METHOD
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
-          - xcode-test-mac@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - deploy-to-bitrise-io@%s: {}
+          - xcode-test-mac@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   macos: []
 warnings_with_recommendations:

--- a/_tests/integration/mac_test.go
+++ b/_tests/integration/mac_test.go
@@ -126,7 +126,10 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - xcode-test-mac@%s: {}
+          - xcode-test-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1575,6 +1575,7 @@ configs:
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1568,13 +1568,19 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - recreate-user-schemes@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
           - cache-push@%s: {}
@@ -1589,10 +1595,14 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - recreate-user-schemes@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
@@ -1617,8 +1627,15 @@ configs:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
           - cocoapods-install@%s: {}
-          - xcode-test-mac@%s: {}
-          - xcode-archive-mac@%s: {}
+          - xcode-test-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+          - xcode-archive-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - export_method: $BITRISE_EXPORT_METHOD
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -1626,9 +1643,14 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - recreate-user-schemes@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
           - cocoapods-install@%s: {}
-          - xcode-test-mac@%s: {}
+          - xcode-test-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
   other:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -260,50 +260,43 @@ var customConfigVersions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// macos
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestMacVersion,
 	steps.XcodeArchiveMacVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.CachePullVersion,
-	steps.ScriptVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestMacVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// other
 	models.FormatVersion,
@@ -1016,8 +1009,7 @@ configs:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html) for signing and deployment options.
             - [Set up code signing with *Android Sign* Step](https://devcenter.bitrise.io/en/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -1050,8 +1042,7 @@ configs:
             Next steps:
             - Check out [Getting started with Android apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-android-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
           - install-missing-android-tools@%s:
@@ -1565,48 +1556,45 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
-          - recreate-user-schemes@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
+          - recreate-user-schemes@%s: {}
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
           - xcode-archive@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-          - deploy-to-bitrise-io@%s: {}
+              - automatic_code_signing: api-key
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
-          - recreate-user-schemes@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
+          - recreate-user-schemes@%s: {}
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - deploy-to-bitrise-io@%s: {}
+              - test_repetition_mode: retry_on_failure
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
   macos:
     default-macos-config: |
       format_version: "%s"
@@ -1620,47 +1608,28 @@ configs:
       workflows:
         deploy:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
           - cocoapods-install@%s: {}
-          - xcode-test-mac@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - xcode-archive-mac@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - export_method: $BITRISE_EXPORT_METHOD
-          - deploy-to-bitrise-io@%s: {}
+          - xcode-test-mac@%s: {}
+          - xcode-archive-mac@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - cache-pull@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - certificate-and-profile-installer@%s: {}
-          - recreate-user-schemes@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
+          - recreate-user-schemes@%s: {}
           - cocoapods-install@%s: {}
-          - xcode-test-mac@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-          - deploy-to-bitrise-io@%s: {}
+          - xcode-test-mac@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
   other:
     other-config: |
       format_version: "%s"

--- a/scanners/ios/appclip.go
+++ b/scanners/ios/appclip.go
@@ -26,6 +26,8 @@ func shouldAppendExportAppClipStep(hasAppClip bool, exportMethod string) bool {
 
 func appendExportAppClipStep(configBuilder *models.ConfigBuilderModel, workflowID models.WorkflowID) {
 	exportXCArchiveStepInputModels := []envmanModels.EnvironmentItemModel{
+		{ProjectPathInputKey: "$" + ProjectPathInputEnvKey},
+		{SchemeInputKey: "$" + SchemeInputEnvKey},
 		{ExportXCArchiveProductInputKey: ExportXCArchiveProductInputAppClipValue},
 		{DistributionMethodInputKey: "$" + DistributionMethodEnvKey},
 		{AutomaticCodeSigningKey: AutomaticCodeSigningValue},

--- a/scanners/ios/appclip.go
+++ b/scanners/ios/appclip.go
@@ -27,6 +27,7 @@ func shouldAppendExportAppClipStep(hasAppClip bool, exportMethod string) bool {
 func appendExportAppClipStep(configBuilder *models.ConfigBuilderModel, workflowID models.WorkflowID) {
 	exportXCArchiveStepInputModels := []envmanModels.EnvironmentItemModel{
 		{ExportXCArchiveProductInputKey: ExportXCArchiveProductInputAppClipValue},
+		{DistributionMethodInputKey: "$" + DistributionMethodEnvKey},
 		{AutomaticCodeSigningKey: AutomaticCodeSigningValue},
 	}
 	configBuilder.AppendStepListItemsTo(workflowID, steps.ExportXCArchiveStepListItem(exportXCArchiveStepInputModels...))

--- a/scanners/ios/appclip.go
+++ b/scanners/ios/appclip.go
@@ -1,0 +1,33 @@
+package ios
+
+import (
+	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/bitrise-init/steps"
+	envmanModels "github.com/bitrise-io/envman/models"
+	"github.com/bitrise-io/go-xcode/xcodeproj"
+)
+
+func schemeHasAppClipTarget(scheme xcodeproj.SchemeModel, targets []xcodeproj.TargetModel) bool {
+	for _, target := range targets {
+		for _, referenceID := range scheme.BuildableReferenceIDs {
+			if referenceID == target.ID && target.HasAppClip {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func shouldAppendExportAppClipStep(hasAppClip bool, exportMethod string) bool {
+	return hasAppClip &&
+		(exportMethod == "development" || exportMethod == "ad-hoc")
+}
+
+func appendExportAppClipStep(configBuilder *models.ConfigBuilderModel, workflowID models.WorkflowID) {
+	exportXCArchiveStepInputModels := []envmanModels.EnvironmentItemModel{
+		{ExportXCArchiveProductInputKey: ExportXCArchiveProductInputAppClipValue},
+		{AutomaticCodeSigningKey: AutomaticCodeSigningValue},
+	}
+	configBuilder.AppendStepListItemsTo(workflowID, steps.ExportXCArchiveStepListItem(exportXCArchiveStepInputModels...))
+}

--- a/scanners/ios/ios.go
+++ b/scanners/ios/ios.go
@@ -59,13 +59,13 @@ func (Scanner) DefaultOptions() models.OptionNode {
 }
 
 // Configs ...
-func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
-	return GenerateConfig(XcodeProjectTypeIOS, scanner.ConfigDescriptors, true)
+func (scanner *Scanner) Configs(isPrivateRepository bool) (models.BitriseConfigMap, error) {
+	return GenerateConfig(XcodeProjectTypeIOS, scanner.ConfigDescriptors, isPrivateRepository)
 }
 
 // DefaultConfigs ...
 func (Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
-	return GenerateDefaultConfig(XcodeProjectTypeIOS, true)
+	return GenerateDefaultConfig(XcodeProjectTypeIOS)
 }
 
 // GetProjectType returns the project_type property used in a bitrise config

--- a/scanners/ios/workflow.go
+++ b/scanners/ios/workflow.go
@@ -109,6 +109,7 @@ func addArchiveStep(workflow models.WorkflowID, configBuilder *models.ConfigBuil
 	switch projectType {
 	case XcodeProjectTypeIOS:
 		inputModels := []envmanModels.EnvironmentItemModel{
+			{DistributionMethodInputKey: "$" + DistributionMethodEnvKey},
 			{AutomaticCodeSigningKey: AutomaticCodeSigningValue},
 		}
 		configBuilder.AppendStepListItemsTo(workflow, steps.XcodeArchiveStepListItem(inputModels...))

--- a/scanners/ios/workflow.go
+++ b/scanners/ios/workflow.go
@@ -1,0 +1,167 @@
+package ios
+
+import (
+	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/bitrise-init/steps"
+	envmanModels "github.com/bitrise-io/envman/models"
+)
+
+const (
+	// TestRepetitionModeKey ...
+	TestRepetitionModeKey = "test_repetition_mode"
+	// TestRepetitionModeRetryOnFailureValue ...
+	TestRepetitionModeRetryOnFailureValue = "retry_on_failure"
+	// BuildForTestDestinationKey ...
+	BuildForTestDestinationKey = "destination"
+	// BuildForTestDestinationValue ...
+	BuildForTestDestinationValue = "platform=iOS Simulator,name=iPhone 8 Plus,OS=latest"
+	// AutomaticCodeSigningKey ...
+	AutomaticCodeSigningKey = "automatic_code_signing"
+	// AutomaticCodeSigningValue ...
+	AutomaticCodeSigningValue = "api-key"
+)
+
+const primaryTestDescription = `The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.`
+
+const primaryBuildOnlyDescription = `The workflow only builds the project because the project scanner could not find any tests.`
+
+const primaryCommonDescription = `Next steps:
+- Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+`
+
+const deployDescription = `The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+For testing the *retry_on_failure* test repetition mode is enabled.
+
+Next steps:
+- Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+- Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
+`
+
+type workflowSetupParams struct {
+	projectType          XcodeProjectType
+	configBuilder        *models.ConfigBuilderModel
+	isPrivateRepository  bool
+	includeCache         bool
+	missingSharedSchemes bool
+	hasTests             bool
+	hasAppClip           bool
+	hasPodfile           bool
+	carthageCommand      string
+	exportMethod         string
+}
+
+func createPrimaryWorkflow(params workflowSetupParams) {
+	identifier := models.PrimaryWorkflowID
+	addSharedSetupSteps(identifier, params, false)
+
+	var description string
+
+	if params.hasTests {
+		description = primaryTestDescription
+		addTestStep(identifier, params.configBuilder, params.projectType)
+	} else {
+		description = primaryBuildOnlyDescription
+		addBuildStep(identifier, params.configBuilder, params.projectType)
+	}
+
+	addSharedTeardownSteps(identifier, params.configBuilder, params.includeCache)
+	addDescription(params.projectType, identifier, params.configBuilder, description+"\n\n"+primaryCommonDescription)
+}
+
+func createDeployWorkflow(params workflowSetupParams) {
+	identifier := models.DeployWorkflowID
+	includeCertificateAndProfileInstallStep := params.projectType == XcodeProjectTypeMacOS
+	addSharedSetupSteps(identifier, params, includeCertificateAndProfileInstallStep)
+
+	if params.hasTests {
+		addTestStep(identifier, params.configBuilder, params.projectType)
+	}
+
+	addArchiveStep(identifier, params.configBuilder, params.projectType, params.hasAppClip, params.exportMethod)
+	addSharedTeardownSteps(identifier, params.configBuilder, params.includeCache)
+	addDescription(params.projectType, identifier, params.configBuilder, deployDescription)
+}
+
+// Helpers
+
+func addTestStep(workflow models.WorkflowID, configBuilder *models.ConfigBuilderModel, projectType XcodeProjectType) {
+	switch projectType {
+	case XcodeProjectTypeIOS:
+		configBuilder.AppendStepListItemsTo(workflow, steps.XcodeTestStepListItem(xcodeTestStepInputModels()...))
+	case XcodeProjectTypeMacOS:
+		configBuilder.AppendStepListItemsTo(workflow, steps.XcodeTestMacStepListItem())
+	}
+}
+
+func addBuildStep(workflow models.WorkflowID, configBuilder *models.ConfigBuilderModel, projectType XcodeProjectType) {
+	if projectType != XcodeProjectTypeIOS {
+		return
+	}
+
+	inputModels := []envmanModels.EnvironmentItemModel{
+		{BuildForTestDestinationKey: BuildForTestDestinationValue},
+	}
+	configBuilder.AppendStepListItemsTo(workflow, steps.XcodeBuildForTestStepListItem(inputModels...))
+}
+
+func addArchiveStep(workflow models.WorkflowID, configBuilder *models.ConfigBuilderModel, projectType XcodeProjectType, hasAppClip bool, exportMethod string) {
+	switch projectType {
+	case XcodeProjectTypeIOS:
+		inputModels := []envmanModels.EnvironmentItemModel{
+			{AutomaticCodeSigningKey: AutomaticCodeSigningValue},
+		}
+		configBuilder.AppendStepListItemsTo(workflow, steps.XcodeArchiveStepListItem(inputModels...))
+
+		if shouldAppendExportAppClipStep(hasAppClip, exportMethod) {
+			appendExportAppClipStep(configBuilder, workflow)
+		}
+	case XcodeProjectTypeMacOS:
+		configBuilder.AppendStepListItemsTo(workflow, steps.XcodeArchiveMacStepListItem())
+	}
+}
+
+func addSharedSetupSteps(workflow models.WorkflowID, params workflowSetupParams, includeCertificateAndProfileInstallStep bool) {
+	params.configBuilder.AppendStepListItemsTo(workflow, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
+		ShouldIncludeCache:       params.includeCache,
+		ShouldIncludeActivateSSH: params.isPrivateRepository,
+	})...)
+
+	if includeCertificateAndProfileInstallStep {
+		params.configBuilder.AppendStepListItemsTo(workflow, steps.CertificateAndProfileInstallerStepListItem())
+	}
+
+	if params.missingSharedSchemes {
+		params.configBuilder.AppendStepListItemsTo(workflow, steps.RecreateUserSchemesStepListItem(
+			envmanModels.EnvironmentItemModel{ProjectPathInputKey: "$" + ProjectPathInputEnvKey},
+		))
+	}
+
+	if params.hasPodfile {
+		params.configBuilder.AppendStepListItemsTo(workflow, steps.CocoapodsInstallStepListItem())
+	}
+
+	if params.carthageCommand != "" {
+		params.configBuilder.AppendStepListItemsTo(workflow, steps.CarthageStepListItem(
+			envmanModels.EnvironmentItemModel{CarthageCommandInputKey: params.carthageCommand},
+		))
+	}
+}
+
+func addSharedTeardownSteps(workflow models.WorkflowID, configBuilder *models.ConfigBuilderModel, includeCache bool) {
+	configBuilder.AppendStepListItemsTo(workflow, steps.DefaultDeployStepListV2(includeCache)...)
+}
+
+func addDescription(projectType XcodeProjectType, workflow models.WorkflowID, configBuilder *models.ConfigBuilderModel, description string) {
+	if projectType != XcodeProjectTypeIOS {
+		return
+	}
+
+	configBuilder.SetWorkflowDescriptionTo(workflow, description)
+}
+
+func xcodeTestStepInputModels() []envmanModels.EnvironmentItemModel {
+	return []envmanModels.EnvironmentItemModel{
+		{TestRepetitionModeKey: TestRepetitionModeRetryOnFailureValue},
+	}
+}

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -60,11 +60,11 @@ func (Scanner) DefaultOptions() models.OptionNode {
 }
 
 // Configs ...
-func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
-	return ios.GenerateConfig(ios.XcodeProjectTypeMacOS, scanner.configDescriptors, true)
+func (scanner *Scanner) Configs(isPrivateRepository bool) (models.BitriseConfigMap, error) {
+	return ios.GenerateConfig(ios.XcodeProjectTypeMacOS, scanner.configDescriptors, isPrivateRepository)
 }
 
 // DefaultConfigs ...
 func (Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
-	return ios.GenerateDefaultConfig(ios.XcodeProjectTypeMacOS, true)
+	return ios.GenerateDefaultConfig(ios.XcodeProjectTypeMacOS)
 }

--- a/steps/const.go
+++ b/steps/const.go
@@ -136,6 +136,13 @@ const (
 )
 
 const (
+	// XcodeBuildForTestID ...
+	XcodeBuildForTestID = "xcode-build-for-test"
+	// XcodeBuildForTestVersion ...
+	XcodeBuildForTestVersion = "1"
+)
+
+const (
 	// XcodeArchiveMacID ...
 	XcodeArchiveMacID = "xcode-archive-mac"
 	// XcodeArchiveMacVersion ...

--- a/steps/steps.go
+++ b/steps/steps.go
@@ -39,8 +39,9 @@ func stepListItem(stepIDComposite, title, runIf string, inputs ...envmanModels.E
 
 // DefaultPrepareStepList ...
 func DefaultPrepareStepList(isIncludeCache bool) []bitriseModels.StepListItemModel {
+	runIfCondition := `{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}`
 	stepList := []bitriseModels.StepListItemModel{
-		ActivateSSHKeyStepListItem(),
+		ActivateSSHKeyStepListItem(runIfCondition),
 		GitCloneStepListItem(),
 	}
 
@@ -56,7 +57,7 @@ func DefaultPrepareStepListV2(params PrepareListParams) []bitriseModels.StepList
 	stepList := []bitriseModels.StepListItemModel{}
 
 	if params.ShouldIncludeActivateSSH {
-		stepList = append(stepList, ActivateSSHKeyStepListItem())
+		stepList = append(stepList, ActivateSSHKeyStepListItem(""))
 	}
 
 	stepList = append(stepList, GitCloneStepListItem())
@@ -95,10 +96,9 @@ func DefaultDeployStepListV2(shouldIncludeCache bool) []bitriseModels.StepListIt
 }
 
 // ActivateSSHKeyStepListItem ...
-func ActivateSSHKeyStepListItem() bitriseModels.StepListItemModel {
+func ActivateSSHKeyStepListItem(runIfCondition string) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(ActivateSSHKeyID, ActivateSSHKeyVersion)
-	runIf := `{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}`
-	return stepListItem(stepIDComposite, "", runIf)
+	return stepListItem(stepIDComposite, "", runIfCondition)
 }
 
 // AndroidLintStepListItem ...
@@ -200,6 +200,12 @@ func RecreateUserSchemesStepListItem(inputs ...envmanModels.EnvironmentItemModel
 // XcodeArchiveStepListItem ...
 func XcodeArchiveStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(XcodeArchiveID, XcodeArchiveVersion)
+	return stepListItem(stepIDComposite, "", "", inputs...)
+}
+
+// XcodeBuildForTestStepListItem ...
+func XcodeBuildForTestStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(XcodeBuildForTestID, XcodeBuildForTestVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 


### PR DESCRIPTION
Tickets:
- https://bitrise.atlassian.net/browse/STEP-1750
- https://bitrise.atlassian.net/browse/STEP-1749

Changes:
- Appclip related logic is extracted to a dedicated file
- The workflow generation is also extracted into a separate file
    - The three different hard coded paths are unified
    - The common elements are shared between the two workflows
- Xcode build for test step is added 
- The integration tests are updated to reflect the changes