### PR TITLE
Updating react-native workflows

### DIFF
--- a/_tests/integration/reactnative_expo_test.go
+++ b/_tests/integration/reactnative_expo_test.go
@@ -382,17 +382,15 @@ var sampleAppsExpoBareVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
+	steps.YarnVersion,
 	steps.YarnVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.AndroidBuildVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeArchiveVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
 	steps.DeployToBitriseIoVersion,
@@ -504,18 +502,18 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - yarn@%s:
               inputs:
               - command: install
+          - yarn@%s:
+              inputs:
+              - command: test
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-          - certificate-and-profile-installer@%s: {}
           - cocoapods-install@2: {}
           - xcode-archive@%s:
               inputs:
@@ -523,14 +521,13 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - configuration: Release
+              - automatic_code_signing: api-key
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - yarn@%s:
               inputs:
               - command: install

--- a/_tests/integration/reactnative_expo_test.go
+++ b/_tests/integration/reactnative_expo_test.go
@@ -499,8 +499,7 @@ configs:
             next change in your repository that matches any of your trigger map event will
             start **deploy** workflow.\n"
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - yarn@%s:
               inputs:
@@ -525,8 +524,7 @@ configs:
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - yarn@%s:
               inputs:

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -265,8 +265,7 @@ configs:
             next change in your repository that matches any of your trigger map event will
             start **deploy** workflow.\n"
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - npm@%s:
               inputs:
@@ -292,8 +291,7 @@ configs:
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - npm@%s:
               inputs:
@@ -449,8 +447,7 @@ configs:
             next change in your repository that matches any of your trigger map event will
             start **deploy** workflow.\n"
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - npm@%s:
               inputs:
@@ -474,8 +471,7 @@ configs:
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - npm@%s:
               inputs:
@@ -627,8 +623,7 @@ configs:
             next change in your repository that matches any of your trigger map event will
             start **deploy** workflow.\n"
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - npm@%s:
               inputs:
@@ -649,8 +644,7 @@ configs:
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - npm@%s:
               inputs:
@@ -801,8 +795,7 @@ configs:
             next change in your repository that matches any of your trigger map event will
             start **deploy** workflow.\n"
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - yarn@%s:
               inputs:
@@ -826,8 +819,7 @@ configs:
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - yarn@%s:
               inputs:

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,14 +15,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	noTestPackageJSON = `{
+  "name": "SampleAppsReactNativeAndroid",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "node node_modules/react-native/local-cli/cli.js start"
+  },
+  "dependencies": {
+    "react": "15.4.2",
+    "react-native": "0.42.0"
+  },
+  "devDependencies": {
+    "babel-jest": "19.0.0",
+    "babel-preset-react-native": "1.9.1",
+    "jest": "19.0.2",
+    "react-test-renderer": "15.4.2"
+  },
+  "jest": {
+    "preset": "react-native"
+  }
+}`
+)
+
 func TestReactNative(t *testing.T) {
 	tmpDir, err := pathutil.NormalizedOSTempDirPath("__reactnative__")
 	require.NoError(t, err)
 
+	const simpleSample = "https://github.com/bitrise-samples/sample-apps-react-native-ios-and-android.git"
+
 	t.Log("sample-apps-react-native-ios-and-android")
 	{
 		sampleAppDir := filepath.Join(tmpDir, "sample-apps-react-native-ios-and-android")
-		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-react-native-ios-and-android.git"
+		sampleAppURL := simpleSample
 		gitClone(t, sampleAppDir, sampleAppURL)
 
 		cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
@@ -36,10 +63,31 @@ func TestReactNative(t *testing.T) {
 		validateConfigExpectation(t, "sample-apps-react-native-ios-and-android", strings.TrimSpace(sampleAppsReactNativeIosAndAndroidResultYML), strings.TrimSpace(result), sampleAppsReactNativeIosAndAndroidVersions...)
 	}
 
+	t.Log("sample-apps-react-native-ios-and-android-no-test")
+	{
+		sampleAppDir := filepath.Join(tmpDir, "sample-apps-react-native-ios-and-android-no-test")
+		sampleAppURL := simpleSample
+		gitClone(t, sampleAppDir, sampleAppURL)
+
+		err := ioutil.WriteFile(filepath.Join(sampleAppDir, "package.json"), []byte(noTestPackageJSON), 0600)
+		require.NoError(t, err)
+
+		cmd := command.New(binPath(), "--ci", "config", "--dir", sampleAppDir, "--output-dir", sampleAppDir)
+		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		scanResultPth := filepath.Join(sampleAppDir, "result.yml")
+
+		result, err := fileutil.ReadStringFromFile(scanResultPth)
+		require.NoError(t, err)
+
+		validateConfigExpectation(t, "sample-apps-react-native-ios-and-android-no-test", strings.TrimSpace(sampleAppsReactNativeIosAndAndroidNoTestResultYML), strings.TrimSpace(result), sampleAppsReactNativeIosAndAndroidNoTestVersions...)
+	}
+
 	t.Log("sample-apps-react-native-ios-and-android-yarn")
 	{
 		sampleAppDir := filepath.Join(tmpDir, "sample-apps-react-native-ios-and-android-yarn")
-		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-react-native-ios-and-android.git"
+		sampleAppURL := simpleSample
 		gitClone(t, sampleAppDir, sampleAppURL)
 
 		yarnCommand := command.New("yarn", "install")
@@ -83,17 +131,15 @@ var sampleAppsReactNativeSubdirVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
+	steps.NpmVersion,
 	steps.NpmVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.AndroidBuildVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeArchiveVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.NpmVersion,
 	steps.NpmVersion,
 	steps.DeployToBitriseIoVersion,
@@ -222,33 +268,33 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - npm@%s:
               inputs:
               - workdir: project
               - command: install
+          - npm@%s:
+              inputs:
+              - workdir: project
+              - command: test
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-          - certificate-and-profile-installer@%s: {}
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - configuration: Release
+              - automatic_code_signing: api-key
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - npm@%s:
               inputs:
               - workdir: project
@@ -269,17 +315,15 @@ var sampleAppsReactNativeIosAndAndroidVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
+	steps.NpmVersion,
 	steps.NpmVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.AndroidBuildVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeArchiveVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.NpmVersion,
 	steps.NpmVersion,
 	steps.DeployToBitriseIoVersion,
@@ -408,32 +452,31 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - npm@%s:
               inputs:
               - command: install
+          - npm@%s:
+              inputs:
+              - command: test
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-          - certificate-and-profile-installer@%s: {}
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - configuration: Release
+              - automatic_code_signing: api-key
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - npm@%s:
               inputs:
               - command: install
@@ -447,22 +490,192 @@ warnings_with_recommendations:
   react-native: []
 `, sampleAppsReactNativeIosAndAndroidVersions...)
 
-var sampleAppsReactNativeIosAndAndroidYarnVersions = []interface{}{
+var sampleAppsReactNativeIosAndAndroidNoTestVersions = []interface{}{
 	models.FormatVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.YarnVersion,
+	steps.NpmVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.AndroidBuildVersion,
-	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeArchiveVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
+	steps.NpmVersion,
+	steps.DeployToBitriseIoVersion,
+}
+
+var sampleAppsReactNativeIosAndAndroidNoTestResultYML = fmt.Sprintf(`options:
+  react-native:
+    title: The root directory of an Android project
+    summary: The root directory of your Android project, stored as an Environment
+      Variable. In your Workflows, you can specify paths relative to this path. You
+      can change this at any time.
+    env_key: PROJECT_LOCATION
+    type: selector
+    value_map:
+      android:
+        title: Module
+        summary: Modules provide a container for your Android project's source code,
+          resource files, and app level settings, such as the module-level build file
+          and Android manifest file. Each module can be independently built, tested,
+          and debugged. You can add new modules to your Bitrise builds at any time.
+        env_key: MODULE
+        type: user_input
+        value_map:
+          app:
+            title: Variant
+            summary: Your Android build variant. You can add variants at any time,
+              as well as further configure your existing variants later.
+            env_key: VARIANT
+            type: user_input_optional
+            value_map:
+              "":
+                title: Project or Workspace path
+                summary: The location of your Xcode project or Xcode workspace files,
+                  stored as an Environment Variable. In your Workflows, you can specify
+                  paths relative to this path.
+                env_key: BITRISE_PROJECT_PATH
+                type: selector
+                value_map:
+                  ios/SampleAppsReactNativeAndroid.xcodeproj:
+                    title: Scheme name
+                    summary: An Xcode scheme defines a collection of targets to build,
+                      a configuration to use when building, and a collection of tests
+                      to execute. Only shared schemes are detected automatically but
+                      you can use any scheme as a target on Bitrise. You can change
+                      the scheme at any time in your Env Vars.
+                    env_key: BITRISE_SCHEME
+                    type: selector
+                    value_map:
+                      SampleAppsReactNativeAndroid:
+                        title: Distribution method
+                        summary: The export method used to create an .ipa file in
+                          your builds, stored as an Environment Variable. You can
+                          change this at any time, or even create several .ipa files
+                          with different export methods in the same build.
+                        env_key: BITRISE_DISTRIBUTION_METHOD
+                        type: selector
+                        value_map:
+                          ad-hoc:
+                            config: react-native-android-ios-config
+                          app-store:
+                            config: react-native-android-ios-config
+                          development:
+                            config: react-native-android-ios-config
+                          enterprise:
+                            config: react-native-android-ios-config
+                      SampleAppsReactNativeAndroid-tvOS:
+                        title: Distribution method
+                        summary: The export method used to create an .ipa file in
+                          your builds, stored as an Environment Variable. You can
+                          change this at any time, or even create several .ipa files
+                          with different export methods in the same build.
+                        env_key: BITRISE_DISTRIBUTION_METHOD
+                        type: selector
+                        value_map:
+                          ad-hoc:
+                            config: react-native-android-ios-config
+                          app-store:
+                            config: react-native-android-ios-config
+                          development:
+                            config: react-native-android-ios-config
+                          enterprise:
+                            config: react-native-android-ios-config
+configs:
+  react-native:
+    react-native-android-ios-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: react-native
+      trigger_map:
+      - push_branch: '*'
+        workflow: primary
+      - pull_request_source_branch: '*'
+        workflow: primary
+      workflows:
+        deploy:
+          description: "## Configure Android part of the deploy workflow\n\nTo generate
+            a signed APK:\n\n1. Open the **Workflow** tab of your project on Bitrise.io\n1.
+            Add **Sign APK step right after Android Build step**\n1. Click on **Code Signing**
+            tab\n1. Find the **ANDROID KEYSTORE FILE** section\n1. Click or drop your file
+            on the upload file field\n1. Fill the displayed 3 input fields:\n1. **Keystore
+            password**\n1. **Keystore alias**\n1. **Private key password**\n1. Click on
+            **[Save metadata]** button\n\nThat's it! From now on, **Sign APK** step will
+            receive your uploaded files.\n\n## Configure iOS part of the deploy workflow\n\nTo
+            generate IPA:\n\n1. Open the **Workflow** tab of your project on Bitrise.io\n1.
+            Click on **Code Signing** tab\n1. Find the **PROVISIONING PROFILE** section\n1.
+            Click or drop your file on the upload file field\n1. Find the **CODE SIGNING
+            IDENTITY** section\n1. Click or drop your file on the upload file field\n1.
+            Click on **Workflows** tab\n1. Select deploy workflow\n1. Select **Xcode Archive
+            & Export for iOS** step\n1. Open **Force Build Settings** input group\n1. Specify
+            codesign settings\nSet **Force code signing with Development Team**, **Force
+            code signing with Code Signing Identity**  \nand **Force code signing with Provisioning
+            Profile** inputs regarding to the uploaded codesigning files\n1. Specify manual
+            codesign style\nIf the codesigning files, are generated manually on the Apple
+            Developer Portal,  \nyou need to explicitly specify to use manual coedsign settings
+            \ \n(as ejected rn projects have xcode managed codesigning turned on).  \nTo
+            do so, add 'CODE_SIGN_STYLE=\"Manual\"' to 'Additional options for xcodebuild
+            call' input\n\n## To run this workflow\n\nIf you want to run this workflow manually:\n\n1.
+            Open the app's build list page\n2. Click on **[Start/Schedule a Build]** button\n3.
+            Select **deploy** in **Workflow** dropdown input\n4. Click **[Start Build]**
+            button\n\nOr if you need this workflow to be started by a GIT event:\n\n1. Click
+            on **Triggers** tab\n2. Setup your desired event (push/tag/pull) and select
+            **deploy** workflow\n3. Click on **[Done]** and then **[Save]** buttons\n\nThe
+            next change in your repository that matches any of your trigger map event will
+            start **deploy** workflow.\n"
+          steps:
+          - activate-ssh-key@%s:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@%s: {}
+          - npm@%s:
+              inputs:
+              - command: install
+          - install-missing-android-tools@%s:
+              inputs:
+              - gradlew_path: $PROJECT_LOCATION/gradlew
+          - android-build@%s:
+              inputs:
+              - project_location: $PROJECT_LOCATION
+          - xcode-archive@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
+              - configuration: Release
+              - automatic_code_signing: api-key
+          - deploy-to-bitrise-io@%s: {}
+        primary:
+          steps:
+          - activate-ssh-key@%s:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@%s: {}
+          - npm@%s:
+              inputs:
+              - command: install
+          - deploy-to-bitrise-io@%s: {}
+warnings:
+  react-native: []
+warnings_with_recommendations:
+  react-native: []
+`, sampleAppsReactNativeIosAndAndroidNoTestVersions...)
+
+var sampleAppsReactNativeIosAndAndroidYarnVersions = []interface{}{
+	models.FormatVersion,
+
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.YarnVersion,
+	steps.YarnVersion,
+	steps.InstallMissingAndroidToolsVersion,
+	steps.AndroidBuildVersion,
+	steps.XcodeArchiveVersion,
+	steps.DeployToBitriseIoVersion,
+
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
 	steps.DeployToBitriseIoVersion,
@@ -591,32 +804,31 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - yarn@%s:
               inputs:
               - command: install
+          - yarn@%s:
+              inputs:
+              - command: test
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
-          - certificate-and-profile-installer@%s: {}
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - configuration: Release
+              - automatic_code_signing: api-key
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - yarn@%s:
               inputs:
               - command: install

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -90,6 +90,13 @@ const (
 )
 
 const (
+	// AutomaticCodeSigningInputKey ...
+	AutomaticCodeSigningInputKey = "automatic_code_signing"
+	// AutomaticCodeSigningInputAPIKeyValue ...
+	AutomaticCodeSigningInputAPIKeyValue = "api-key"
+)
+
+const (
 	// CarthageCommandInputKey ...
 	CarthageCommandInputKey = "carthage_command"
 )

--- a/scanners/reactnative/const.go
+++ b/scanners/reactnative/const.go
@@ -1,6 +1,7 @@
 package reactnative
 
-const deployWorkflowDescription = `## Configure Android part of the deploy workflow
+const (
+	deployWorkflowDescription = `## Configure Android part of the deploy workflow
 
 To generate a signed APK:
 
@@ -57,3 +58,4 @@ Or if you need this workflow to be started by a GIT event:
 
 The next change in your repository that matches any of your trigger map event will start **deploy** workflow.
 `
+)

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -158,7 +158,7 @@ func (scanner *Scanner) defaultOptions() models.OptionNode {
 }
 
 // configs implements ScannerInterface.Configs function for plain React Native projects.
-func (scanner *Scanner) configs() (models.BitriseConfigMap, error) {
+func (scanner *Scanner) configs(isPrivateRepo bool) (models.BitriseConfigMap, error) {
 	configMap := models.BitriseConfigMap{}
 
 	packageJSONDir := filepath.Dir(scanner.packageJSONPth)
@@ -171,91 +171,65 @@ func (scanner *Scanner) configs() (models.BitriseConfigMap, error) {
 		relPackageJSONDir = ""
 	}
 
-	workdirEnvList := []envmanModels.EnvironmentItemModel{}
-	if relPackageJSONDir != "" {
-		workdirEnvList = append(workdirEnvList, envmanModels.EnvironmentItemModel{workDirInputKey: relPackageJSONDir})
+	configBuilder := models.NewDefaultConfigBuilder()
+
+	// ci
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
+		ShouldIncludeCache:       false,
+		ShouldIncludeActivateSSH: isPrivateRepo,
+	})...)
+	scanner.addTestSteps(configBuilder, models.PrimaryWorkflowID, relPackageJSONDir)
+
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(false)...)
+
+	// cd
+	configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployWorkflowDescription)
+	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
+		ShouldIncludeCache:       false,
+		ShouldIncludeActivateSSH: isPrivateRepo,
+	})...)
+	scanner.addTestSteps(configBuilder, models.DeployWorkflowID, relPackageJSONDir)
+
+	// android cd
+	if scanner.androidScanner != nil {
+		projectLocationEnv := "$" + android.ProjectLocationInputEnvKey
+
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.InstallMissingAndroidToolsStepListItem(
+			envmanModels.EnvironmentItemModel{android.GradlewPathInputKey: "$" + android.ProjectLocationInputEnvKey + "/gradlew"},
+		))
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.AndroidBuildStepListItem(
+			envmanModels.EnvironmentItemModel{android.ProjectLocationInputKey: projectLocationEnv},
+		))
 	}
 
-	if scanner.hasTest {
-		configBuilder := models.NewDefaultConfigBuilder()
-
-		// ci
-		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(false)...)
-		if scanner.hasYarnLockFile {
-			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.YarnStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "install"})...))
-			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.YarnStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "test"})...))
-		} else {
-			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "install"})...))
-			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "test"})...))
-		}
-		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
-
-		// cd
-		configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployWorkflowDescription)
-		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepList(false)...)
-		if scanner.hasYarnLockFile {
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.YarnStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "install"})...))
-		} else {
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.NpmStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "install"})...))
-		}
-
-		// android cd
-		if scanner.androidScanner != nil {
-			projectLocationEnv := "$" + android.ProjectLocationInputEnvKey
-
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.InstallMissingAndroidToolsStepListItem(
-				envmanModels.EnvironmentItemModel{android.GradlewPathInputKey: "$" + android.ProjectLocationInputEnvKey + "/gradlew"},
-			))
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.AndroidBuildStepListItem(
-				envmanModels.EnvironmentItemModel{android.ProjectLocationInputKey: projectLocationEnv},
-			))
-		}
-
-		// ios cd
-		if scanner.iosScanner != nil {
-			for _, descriptor := range scanner.iosScanner.ConfigDescriptors {
-				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
-
-				if descriptor.MissingSharedSchemes {
-					configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.RecreateUserSchemesStepListItem(
-						envmanModels.EnvironmentItemModel{ios.ProjectPathInputKey: "$" + ios.ProjectPathInputEnvKey},
-					))
-				}
-
-				if descriptor.HasPodfile {
-					configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CocoapodsInstallStepListItem())
-				}
-
-				if descriptor.CarthageCommand != "" {
-					configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CarthageStepListItem(
-						envmanModels.EnvironmentItemModel{ios.CarthageCommandInputKey: descriptor.CarthageCommand},
-					))
-				}
-
-				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveStepListItem(
+	// ios cd
+	if scanner.iosScanner != nil {
+		for _, descriptor := range scanner.iosScanner.ConfigDescriptors {
+			if descriptor.MissingSharedSchemes {
+				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.RecreateUserSchemesStepListItem(
 					envmanModels.EnvironmentItemModel{ios.ProjectPathInputKey: "$" + ios.ProjectPathInputEnvKey},
-					envmanModels.EnvironmentItemModel{ios.SchemeInputKey: "$" + ios.SchemeInputEnvKey},
-					envmanModels.EnvironmentItemModel{ios.DistributionMethodInputKey: "$" + ios.DistributionMethodEnvKey},
-					envmanModels.EnvironmentItemModel{ios.ConfigurationInputKey: "Release"},
 				))
-
-				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepList(false)...)
-
-				bitriseDataModel, err := configBuilder.Generate(scannerName)
-				if err != nil {
-					return models.BitriseConfigMap{}, err
-				}
-
-				data, err := yaml.Marshal(bitriseDataModel)
-				if err != nil {
-					return models.BitriseConfigMap{}, err
-				}
-
-				configName := configName(scanner.androidScanner != nil, true, true)
-				configMap[configName] = string(data)
 			}
-		} else {
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepList(false)...)
+
+			if descriptor.HasPodfile {
+				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CocoapodsInstallStepListItem())
+			}
+
+			if descriptor.CarthageCommand != "" {
+				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CarthageStepListItem(
+					envmanModels.EnvironmentItemModel{ios.CarthageCommandInputKey: descriptor.CarthageCommand},
+				))
+			}
+
+			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveStepListItem(
+				envmanModels.EnvironmentItemModel{ios.ProjectPathInputKey: "$" + ios.ProjectPathInputEnvKey},
+				envmanModels.EnvironmentItemModel{ios.SchemeInputKey: "$" + ios.SchemeInputEnvKey},
+				envmanModels.EnvironmentItemModel{ios.DistributionMethodInputKey: "$" + ios.DistributionMethodEnvKey},
+				envmanModels.EnvironmentItemModel{ios.ConfigurationInputKey: "Release"},
+				envmanModels.EnvironmentItemModel{ios.AutomaticCodeSigningInputKey: ios.AutomaticCodeSigningInputAPIKeyValue},
+			))
+
+			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepListV2(false)...)
 
 			bitriseDataModel, err := configBuilder.Generate(scannerName)
 			if err != nil {
@@ -267,85 +241,24 @@ func (scanner *Scanner) configs() (models.BitriseConfigMap, error) {
 				return models.BitriseConfigMap{}, err
 			}
 
-			configName := configName(scanner.androidScanner != nil, false, true)
+			configName := configName(scanner.androidScanner != nil, true, scanner.hasTest)
 			configMap[configName] = string(data)
 		}
 	} else {
-		configBuilder := models.NewDefaultConfigBuilder()
-		configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployWorkflowDescription)
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepListV2(false)...)
 
-		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(false)...)
-		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "install"})...))
-
-		if scanner.androidScanner != nil {
-			projectLocationEnv := "$" + android.ProjectLocationInputEnvKey
-
-			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.InstallMissingAndroidToolsStepListItem(
-				envmanModels.EnvironmentItemModel{android.GradlewPathInputKey: "$" + android.ProjectLocationInputEnvKey + "/gradlew"},
-			))
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.AndroidBuildStepListItem(
-				envmanModels.EnvironmentItemModel{android.ProjectLocationInputKey: projectLocationEnv},
-			))
+		bitriseDataModel, err := configBuilder.Generate(scannerName)
+		if err != nil {
+			return models.BitriseConfigMap{}, err
 		}
 
-		if scanner.iosScanner != nil {
-			for _, descriptor := range scanner.iosScanner.ConfigDescriptors {
-				configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
-
-				if descriptor.MissingSharedSchemes {
-					configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RecreateUserSchemesStepListItem(
-						envmanModels.EnvironmentItemModel{ios.ProjectPathInputKey: "$" + ios.ProjectPathInputEnvKey},
-					))
-				}
-
-				if descriptor.HasPodfile {
-					configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CocoapodsInstallStepListItem())
-				}
-
-				if descriptor.CarthageCommand != "" {
-					configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CarthageStepListItem(
-						envmanModels.EnvironmentItemModel{ios.CarthageCommandInputKey: descriptor.CarthageCommand},
-					))
-				}
-
-				configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.XcodeArchiveStepListItem(
-					envmanModels.EnvironmentItemModel{ios.ProjectPathInputKey: "$" + ios.ProjectPathInputEnvKey},
-					envmanModels.EnvironmentItemModel{ios.SchemeInputKey: "$" + ios.SchemeInputEnvKey},
-					envmanModels.EnvironmentItemModel{ios.DistributionMethodInputKey: "$" + ios.DistributionMethodEnvKey},
-					envmanModels.EnvironmentItemModel{ios.ConfigurationInputKey: "Release"},
-				))
-
-				configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
-
-				bitriseDataModel, err := configBuilder.Generate(scannerName)
-				if err != nil {
-					return models.BitriseConfigMap{}, err
-				}
-
-				data, err := yaml.Marshal(bitriseDataModel)
-				if err != nil {
-					return models.BitriseConfigMap{}, err
-				}
-
-				configName := configName(scanner.androidScanner != nil, true, false)
-				configMap[configName] = string(data)
-			}
-		} else {
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepList(false)...)
-
-			bitriseDataModel, err := configBuilder.Generate(scannerName)
-			if err != nil {
-				return models.BitriseConfigMap{}, err
-			}
-
-			data, err := yaml.Marshal(bitriseDataModel)
-			if err != nil {
-				return models.BitriseConfigMap{}, err
-			}
-
-			configName := configName(scanner.androidScanner != nil, false, false)
-			configMap[configName] = string(data)
+		data, err := yaml.Marshal(bitriseDataModel)
+		if err != nil {
+			return models.BitriseConfigMap{}, err
 		}
+
+		configName := configName(scanner.androidScanner != nil, false, scanner.hasTest)
+		configMap[configName] = string(data)
 	}
 
 	return configMap, nil
@@ -403,4 +316,23 @@ func (scanner *Scanner) defaultConfigs() (models.BitriseConfigMap, error) {
 	}
 
 	return configMap, nil
+}
+
+func (scanner *Scanner) addTestSteps(configBuilder *models.ConfigBuilderModel, workflowID models.WorkflowID, workDir string) {
+	workdirEnvList := []envmanModels.EnvironmentItemModel{}
+	if workDir != "" {
+		workdirEnvList = append(workdirEnvList, envmanModels.EnvironmentItemModel{workDirInputKey: workDir})
+	}
+
+	if scanner.hasYarnLockFile {
+		configBuilder.AppendStepListItemsTo(workflowID, steps.YarnStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "install"})...))
+		if scanner.hasTest {
+			configBuilder.AppendStepListItemsTo(workflowID, steps.YarnStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "test"})...))
+		}
+	} else {
+		configBuilder.AppendStepListItemsTo(workflowID, steps.NpmStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "install"})...))
+		if scanner.hasTest {
+			configBuilder.AppendStepListItemsTo(workflowID, steps.NpmStepListItem(append(workdirEnvList, envmanModels.EnvironmentItemModel{"command": "test"})...))
+		}
+	}
 }

--- a/scanners/reactnative/reactnative.go
+++ b/scanners/reactnative/reactnative.go
@@ -258,15 +258,17 @@ func (scanner *Scanner) Options() (options models.OptionNode, warnings models.Wa
 	} else {
 		options, warnings, err = scanner.options()
 	}
+
 	return
 }
 
 // Configs implements ScannerInterface.Configs function.
-func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(isPrivateRepo bool) (models.BitriseConfigMap, error) {
 	if scanner.expoSettings != nil {
 		return scanner.expoConfigs()
 	}
-	return scanner.configs()
+
+	return scanner.configs(isPrivateRepo)
 }
 
 // DefaultOptions implements ScannerInterface.DefaultOptions function.


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [-] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context
Updates react-native workflows:
- Includes _npm_/_yarn_ `test` in **deploy** workflow
- **primary** and **deploy** workflow always created. If tests are not found in the project **primary** workflow contains _npm_/_yarn_ `install` only, but not building the native apps. Previously **primary** took **deploy**'s place in these cases.
- Empty Script Step removed
- _Certificate and profile installer_ Step removed, _Xcode Archive & Export for iOS_'s Automatic code signing option is enabled instead.
- Fixes issue with an invalid workflow generated for projects without tests. (The same logic as for tests is used.)

Resolves
https://bitrise.atlassian.net/browse/STEP-1744
https://bitrise.atlassian.net/browse/STEP-1742


### Changes

Not in scope yet:
- Default workflow updates
- Description updates
- Testing with other sample apps
- Expo primary workflow update

### Decisions

<!-- Please list decisions that were made for this change. -->
