### PR TITLE
Update Flutter primary workflow

### DIFF
--- a/_tests/integration/flutter_test.go
+++ b/_tests/integration/flutter_test.go
@@ -289,8 +289,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -342,8 +341,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -395,8 +393,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -444,8 +441,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -503,8 +499,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -562,8 +557,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -760,8 +754,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -813,8 +806,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -866,8 +858,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -915,8 +906,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -974,8 +964,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1033,8 +1022,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1265,8 +1253,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1318,8 +1305,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1371,8 +1357,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1420,8 +1405,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1479,8 +1463,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1538,8 +1521,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:

--- a/_tests/integration/flutter_test.go
+++ b/_tests/integration/flutter_test.go
@@ -14,11 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFlutter(t *testing.T) {
+func TestFlutterIosAndroid(t *testing.T) {
 	tmpDir, err := pathutil.NormalizedOSTempDirPath("__flutter__")
 	require.NoError(t, err)
 
-	t.Log("sample-apps-flutter-ios-android")
 	{
 		sampleAppDir := filepath.Join(tmpDir, "sample-apps-flutter-ios-android")
 		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-flutter-ios-android.git"
@@ -35,8 +34,11 @@ func TestFlutter(t *testing.T) {
 
 		validateConfigExpectation(t, "sample-apps-flutter-ios-android", strings.TrimSpace(flutterSampleAppResultYML), strings.TrimSpace(result), flutterSampleAppVersions...)
 	}
+}
 
-	t.Log("sample-apps-flutter-ios-android-package")
+func TestFlutterIosAndroidPackage(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("__flutter__")
+	require.NoError(t, err)
 	{
 		sampleAppDir := filepath.Join(tmpDir, "sample-apps-flutter-ios-android-package")
 		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-flutter-ios-android-package.git"
@@ -53,8 +55,10 @@ func TestFlutter(t *testing.T) {
 
 		validateConfigExpectation(t, "sample-apps-flutter-ios-android-package", strings.TrimSpace(flutterSamplePackageResultYML), strings.TrimSpace(result), flutterSamplePackageVersions...)
 	}
-
-	t.Log("sample-apps-flutter-ios-android-plugin")
+}
+func TestFlutterIosAndroidPlugin(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("__flutter__")
+	require.NoError(t, err)
 	{
 		sampleAppDir := filepath.Join(tmpDir, "sample-apps-flutter-ios-android-plugin")
 		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-flutter-ios-android-plugin.git"
@@ -74,18 +78,7 @@ func TestFlutter(t *testing.T) {
 }
 
 var flutterSampleAppVersions = []interface{}{
-	// flutter-config
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.FlutterInstallVersion,
-	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
-	steps.CachePushVersion,
-
-	// flutter-config-app-android
+	// flutter-config-notest-app-android
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -99,14 +92,12 @@ var flutterSampleAppVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
-	// flutter-config-app-both
+	// flutter-config-notest-app-both
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -122,14 +113,12 @@ var flutterSampleAppVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
-	// flutter-config-app-ios
+	// flutter-config-notest-app-ios
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -145,24 +134,10 @@ var flutterSampleAppVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
-
-	// flutter-config-test
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.FlutterInstallVersion,
-	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.FlutterTestVersion,
 	steps.DeployToBitriseIoVersion,
-	steps.CachePushVersion,
 
 	// flutter-config-test-app-android
 	models.FormatVersion,
@@ -179,13 +154,11 @@ var flutterSampleAppVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// flutter-config-test-app-both
 	models.FormatVersion,
@@ -204,13 +177,11 @@ var flutterSampleAppVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// flutter-config-test-app-ios
 	models.FormatVersion,
@@ -229,13 +200,11 @@ var flutterSampleAppVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var flutterSampleAppResultYML = fmt.Sprintf(`options:
@@ -248,109 +217,42 @@ var flutterSampleAppResultYML = fmt.Sprintf(`options:
     type: selector
     value_map:
       .:
-        title: Run tests found in the project
-        summary: Our Flutter Test Step can run the tests found in your project's repository.
+        title: Project or Workspace path
+        summary: The location of your Xcode project or Xcode workspace files, stored
+          as an Environment Variable. In your Workflows, you can specify paths relative
+          to this path.
+        env_key: BITRISE_PROJECT_PATH
         type: selector
         value_map:
-          "no":
-            title: Project or Workspace path
-            summary: The location of your Xcode project or Xcode workspace files,
-              stored as an Environment Variable. In your Workflows, you can specify
-              paths relative to this path.
-            env_key: BITRISE_PROJECT_PATH
+          ios/Runner.xcworkspace:
+            title: Scheme name
+            summary: An Xcode scheme defines a collection of targets to build, a configuration
+              to use when building, and a collection of tests to execute. Only shared
+              schemes are detected automatically but you can use any scheme as a target
+              on Bitrise. You can change the scheme at any time in your Env Vars.
+            env_key: BITRISE_SCHEME
             type: selector
             value_map:
-              ios/Runner.xcworkspace:
-                title: Scheme name
-                summary: An Xcode scheme defines a collection of targets to build,
-                  a configuration to use when building, and a collection of tests
-                  to execute. Only shared schemes are detected automatically but you
-                  can use any scheme as a target on Bitrise. You can change the scheme
-                  at any time in your Env Vars.
-                env_key: BITRISE_SCHEME
+              Runner:
+                title: Distribution method
+                summary: The export method used to create an .ipa file in your builds,
+                  stored as an Environment Variable. You can change this at any time,
+                  or even create several .ipa files with different export methods
+                  in the same build.
+                env_key: BITRISE_DISTRIBUTION_METHOD
                 type: selector
                 value_map:
-                  Runner:
-                    title: Distribution method
-                    summary: The export method used to create an .ipa file in your
-                      builds, stored as an Environment Variable. You can change this
-                      at any time, or even create several .ipa files with different
-                      export methods in the same build.
-                    env_key: BITRISE_DISTRIBUTION_METHOD
-                    type: selector
-                    value_map:
-                      ad-hoc:
-                        config: flutter-config-app-both
-                      app-store:
-                        config: flutter-config-app-both
-                      development:
-                        config: flutter-config-app-both
-                      enterprise:
-                        config: flutter-config-app-both
-          "yes":
-            title: Project or Workspace path
-            summary: The location of your Xcode project or Xcode workspace files,
-              stored as an Environment Variable. In your Workflows, you can specify
-              paths relative to this path.
-            env_key: BITRISE_PROJECT_PATH
-            type: selector
-            value_map:
-              ios/Runner.xcworkspace:
-                title: Scheme name
-                summary: An Xcode scheme defines a collection of targets to build,
-                  a configuration to use when building, and a collection of tests
-                  to execute. Only shared schemes are detected automatically but you
-                  can use any scheme as a target on Bitrise. You can change the scheme
-                  at any time in your Env Vars.
-                env_key: BITRISE_SCHEME
-                type: selector
-                value_map:
-                  Runner:
-                    title: Distribution method
-                    summary: The export method used to create an .ipa file in your
-                      builds, stored as an Environment Variable. You can change this
-                      at any time, or even create several .ipa files with different
-                      export methods in the same build.
-                    env_key: BITRISE_DISTRIBUTION_METHOD
-                    type: selector
-                    value_map:
-                      ad-hoc:
-                        config: flutter-config-test-app-both
-                      app-store:
-                        config: flutter-config-test-app-both
-                      development:
-                        config: flutter-config-test-app-both
-                      enterprise:
-                        config: flutter-config-test-app-both
+                  ad-hoc:
+                    config: flutter-config-test-app-both
+                  app-store:
+                    config: flutter-config-test-app-both
+                  development:
+                    config: flutter-config-test-app-both
+                  enterprise:
+                    config: flutter-config-test-app-both
 configs:
   flutter:
-    flutter-config: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
-      workflows:
-        primary:
-          steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-          - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - flutter-installer@%s:
-              inputs:
-              - is_update: "false"
-          - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
-          - cache-push@%s: {}
-    flutter-config-app-android: |
+    flutter-config-notest-app-android: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -381,22 +283,22 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-app-both: |
+          - deploy-to-bitrise-io@%s: {}
+    flutter-config-notest-app-both: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -434,22 +336,22 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-app-ios: |
+          - deploy-to-bitrise-io@%s: {}
+    flutter-config-notest-app-ios: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -487,50 +389,21 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-test: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
-      workflows:
-        primary:
-          steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-          - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - flutter-installer@%s:
-              inputs:
-              - is_update: "false"
-          - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - flutter-test@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - deploy-to-bitrise-io@%s: {}
-          - cache-push@%s: {}
     flutter-config-test-app-android: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -565,24 +438,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     flutter-config-test-app-both: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -624,24 +497,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     flutter-config-test-app-ios: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -683,24 +556,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   flutter: []
 warnings_with_recommendations:
@@ -708,18 +581,7 @@ warnings_with_recommendations:
 `, flutterSampleAppVersions...)
 
 var flutterSamplePackageVersions = []interface{}{
-	// flutter-config
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.FlutterInstallVersion,
-	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
-	steps.CachePushVersion,
-
-	// flutter-config-app-android
+	// flutter-config-notest-app-android
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -733,14 +595,12 @@ var flutterSamplePackageVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
-	// flutter-config-app-both
+	// flutter-config-notest-app-both
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -756,14 +616,12 @@ var flutterSamplePackageVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
-	// flutter-config-app-ios
+	// flutter-config-notest-app-ios
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -779,24 +637,10 @@ var flutterSamplePackageVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
-
-	// flutter-config-test
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.FlutterInstallVersion,
-	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.FlutterTestVersion,
 	steps.DeployToBitriseIoVersion,
-	steps.CachePushVersion,
 
 	// flutter-config-test-app-android
 	models.FormatVersion,
@@ -813,13 +657,11 @@ var flutterSamplePackageVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// flutter-config-test-app-both
 	models.FormatVersion,
@@ -838,13 +680,11 @@ var flutterSamplePackageVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// flutter-config-test-app-ios
 	models.FormatVersion,
@@ -863,13 +703,11 @@ var flutterSamplePackageVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var flutterSamplePackageResultYML = fmt.Sprintf(`options:
@@ -882,43 +720,10 @@ var flutterSamplePackageResultYML = fmt.Sprintf(`options:
     type: selector
     value_map:
       .:
-        title: Run tests found in the project
-        summary: Our Flutter Test Step can run the tests found in your project's repository.
-        type: selector
-        value_map:
-          "no":
-            config: flutter-config
-          "yes":
-            config: flutter-config-test
+        config: flutter-config-test-app-both
 configs:
   flutter:
-    flutter-config: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
-      workflows:
-        primary:
-          steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-          - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - flutter-installer@%s:
-              inputs:
-              - is_update: "false"
-          - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
-          - cache-push@%s: {}
-    flutter-config-app-android: |
+    flutter-config-notest-app-android: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -949,22 +754,22 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-app-both: |
+          - deploy-to-bitrise-io@%s: {}
+    flutter-config-notest-app-both: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -1002,22 +807,22 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-app-ios: |
+          - deploy-to-bitrise-io@%s: {}
+    flutter-config-notest-app-ios: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -1055,50 +860,21 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-test: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
-      workflows:
-        primary:
-          steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-          - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - flutter-installer@%s:
-              inputs:
-              - is_update: "false"
-          - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - flutter-test@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - deploy-to-bitrise-io@%s: {}
-          - cache-push@%s: {}
     flutter-config-test-app-android: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1133,24 +909,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     flutter-config-test-app-both: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1192,24 +968,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     flutter-config-test-app-ios: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1251,24 +1027,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   flutter: []
 warnings_with_recommendations:
@@ -1276,18 +1052,7 @@ warnings_with_recommendations:
 `, flutterSamplePackageVersions...)
 
 var flutterSamplePluginVersions = []interface{}{
-	// flutter-config
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.FlutterInstallVersion,
-	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
-	steps.CachePushVersion,
-
-	// flutter-config-app-android
+	// flutter-config-notest-app-android
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1301,14 +1066,12 @@ var flutterSamplePluginVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
-	// flutter-config-app-both
+	// flutter-config-notest-app-both
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1324,14 +1087,12 @@ var flutterSamplePluginVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
-	// flutter-config-app-ios
+	// flutter-config-notest-app-ios
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1347,24 +1108,10 @@ var flutterSamplePluginVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
-
-	// flutter-config-test
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.FlutterInstallVersion,
-	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.FlutterTestVersion,
 	steps.DeployToBitriseIoVersion,
-	steps.CachePushVersion,
 
 	// flutter-config-test-app-android
 	models.FormatVersion,
@@ -1381,13 +1128,11 @@ var flutterSamplePluginVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// flutter-config-test-app-both
 	models.FormatVersion,
@@ -1406,13 +1151,11 @@ var flutterSamplePluginVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// flutter-config-test-app-ios
 	models.FormatVersion,
@@ -1431,13 +1174,11 @@ var flutterSamplePluginVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 }
 
 var flutterSamplePluginResultYML = fmt.Sprintf(`options:
@@ -1450,111 +1191,44 @@ var flutterSamplePluginResultYML = fmt.Sprintf(`options:
     type: selector
     value_map:
       .:
-        config: flutter-config-app-android
+        config: flutter-config-notest-app-android
       example:
-        title: Run tests found in the project
-        summary: Our Flutter Test Step can run the tests found in your project's repository.
+        title: Project or Workspace path
+        summary: The location of your Xcode project or Xcode workspace files, stored
+          as an Environment Variable. In your Workflows, you can specify paths relative
+          to this path.
+        env_key: BITRISE_PROJECT_PATH
         type: selector
         value_map:
-          "no":
-            title: Project or Workspace path
-            summary: The location of your Xcode project or Xcode workspace files,
-              stored as an Environment Variable. In your Workflows, you can specify
-              paths relative to this path.
-            env_key: BITRISE_PROJECT_PATH
+          example/ios/Runner.xcworkspace:
+            title: Scheme name
+            summary: An Xcode scheme defines a collection of targets to build, a configuration
+              to use when building, and a collection of tests to execute. Only shared
+              schemes are detected automatically but you can use any scheme as a target
+              on Bitrise. You can change the scheme at any time in your Env Vars.
+            env_key: BITRISE_SCHEME
             type: selector
             value_map:
-              example/ios/Runner.xcworkspace:
-                title: Scheme name
-                summary: An Xcode scheme defines a collection of targets to build,
-                  a configuration to use when building, and a collection of tests
-                  to execute. Only shared schemes are detected automatically but you
-                  can use any scheme as a target on Bitrise. You can change the scheme
-                  at any time in your Env Vars.
-                env_key: BITRISE_SCHEME
+              Runner:
+                title: Distribution method
+                summary: The export method used to create an .ipa file in your builds,
+                  stored as an Environment Variable. You can change this at any time,
+                  or even create several .ipa files with different export methods
+                  in the same build.
+                env_key: BITRISE_DISTRIBUTION_METHOD
                 type: selector
                 value_map:
-                  Runner:
-                    title: Distribution method
-                    summary: The export method used to create an .ipa file in your
-                      builds, stored as an Environment Variable. You can change this
-                      at any time, or even create several .ipa files with different
-                      export methods in the same build.
-                    env_key: BITRISE_DISTRIBUTION_METHOD
-                    type: selector
-                    value_map:
-                      ad-hoc:
-                        config: flutter-config-app-both
-                      app-store:
-                        config: flutter-config-app-both
-                      development:
-                        config: flutter-config-app-both
-                      enterprise:
-                        config: flutter-config-app-both
-          "yes":
-            title: Project or Workspace path
-            summary: The location of your Xcode project or Xcode workspace files,
-              stored as an Environment Variable. In your Workflows, you can specify
-              paths relative to this path.
-            env_key: BITRISE_PROJECT_PATH
-            type: selector
-            value_map:
-              example/ios/Runner.xcworkspace:
-                title: Scheme name
-                summary: An Xcode scheme defines a collection of targets to build,
-                  a configuration to use when building, and a collection of tests
-                  to execute. Only shared schemes are detected automatically but you
-                  can use any scheme as a target on Bitrise. You can change the scheme
-                  at any time in your Env Vars.
-                env_key: BITRISE_SCHEME
-                type: selector
-                value_map:
-                  Runner:
-                    title: Distribution method
-                    summary: The export method used to create an .ipa file in your
-                      builds, stored as an Environment Variable. You can change this
-                      at any time, or even create several .ipa files with different
-                      export methods in the same build.
-                    env_key: BITRISE_DISTRIBUTION_METHOD
-                    type: selector
-                    value_map:
-                      ad-hoc:
-                        config: flutter-config-test-app-both
-                      app-store:
-                        config: flutter-config-test-app-both
-                      development:
-                        config: flutter-config-test-app-both
-                      enterprise:
-                        config: flutter-config-test-app-both
+                  ad-hoc:
+                    config: flutter-config-test-app-both
+                  app-store:
+                    config: flutter-config-test-app-both
+                  development:
+                    config: flutter-config-test-app-both
+                  enterprise:
+                    config: flutter-config-test-app-both
 configs:
   flutter:
-    flutter-config: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
-      workflows:
-        primary:
-          steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-          - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - flutter-installer@%s:
-              inputs:
-              - is_update: "false"
-          - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
-          - cache-push@%s: {}
-    flutter-config-app-android: |
+    flutter-config-notest-app-android: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -1585,22 +1259,22 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-app-both: |
+          - deploy-to-bitrise-io@%s: {}
+    flutter-config-notest-app-both: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -1638,22 +1312,22 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-app-ios: |
+          - deploy-to-bitrise-io@%s: {}
+    flutter-config-notest-app-ios: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -1691,50 +1365,21 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-test: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
-      workflows:
-        primary:
-          steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-          - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - flutter-installer@%s:
-              inputs:
-              - is_update: "false"
-          - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - flutter-test@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - deploy-to-bitrise-io@%s: {}
-          - cache-push@%s: {}
     flutter-config-test-app-android: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1769,24 +1414,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     flutter-config-test-app-both: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1828,24 +1473,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     flutter-config-test-app-ios: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1887,24 +1532,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   flutter: []
 warnings_with_recommendations:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -89,16 +89,7 @@ var customConfigVersions = []interface{}{
 	steps.DeployToBitriseIoVersion,
 
 	// flutter
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.FlutterInstallVersion,
-	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
-	steps.CachePushVersion,
-
+	// flutter-config-notest-app-android
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -112,13 +103,12 @@ var customConfigVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
+	// flutter-config-notest-app-both
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -134,13 +124,12 @@ var customConfigVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
+	// flutter-config-notest-app-ios
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -156,24 +145,12 @@ var customConfigVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
-
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.FlutterInstallVersion,
-	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
-	steps.FlutterTestVersion,
 	steps.DeployToBitriseIoVersion,
-	steps.CachePushVersion,
 
+	// flutter-config-test-app-android
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -188,14 +165,13 @@ var customConfigVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
+	// flutter-config-test-app-both
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -212,14 +188,13 @@ var customConfigVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
+	// flutter-config-test-app-ios
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -236,13 +211,11 @@ var customConfigVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
-	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	// ionic
 	models.FormatVersion,
@@ -436,172 +409,83 @@ var customConfigResultYML = fmt.Sprintf(`options:
     type: user_input
     value_map:
       "":
-        title: Run tests found in the project
-        summary: Our Flutter Test Step can run the tests found in your project's repository.
+        title: Platform
+        summary: The target platform for your first build. Your options are iOS, Android,
+          both, or neither. You can change this in your Env Vars at any time.
         type: selector
         value_map:
-          "no":
-            title: Platform
-            summary: The target platform for your first build. Your options are iOS,
-              Android, both, or neither. You can change this in your Env Vars at any
-              time.
-            type: selector
+          android:
+            config: flutter-config-test-app-android
+          both:
+            title: Project or Workspace path
+            summary: The location of your Xcode project or Xcode workspace files,
+              stored as an Environment Variable. In your Workflows, you can specify
+              paths relative to this path.
+            env_key: BITRISE_PROJECT_PATH
+            type: user_input
             value_map:
-              android:
-                config: flutter-config-app-android
-              both:
-                title: Project or Workspace path
-                summary: The location of your Xcode project or Xcode workspace files,
-                  stored as an Environment Variable. In your Workflows, you can specify
-                  paths relative to this path.
-                env_key: BITRISE_PROJECT_PATH
+              "":
+                title: Scheme name
+                summary: An Xcode scheme defines a collection of targets to build,
+                  a configuration to use when building, and a collection of tests
+                  to execute. Only shared schemes are detected automatically but you
+                  can use any scheme as a target on Bitrise. You can change the scheme
+                  at any time in your Env Vars.
+                env_key: BITRISE_SCHEME
                 type: user_input
                 value_map:
                   "":
-                    title: Scheme name
-                    summary: An Xcode scheme defines a collection of targets to build,
-                      a configuration to use when building, and a collection of tests
-                      to execute. Only shared schemes are detected automatically but
-                      you can use any scheme as a target on Bitrise. You can change
-                      the scheme at any time in your Env Vars.
-                    env_key: BITRISE_SCHEME
-                    type: user_input
+                    title: Distribution method
+                    summary: The export method used to create an .ipa file in your
+                      builds, stored as an Environment Variable. You can change this
+                      at any time, or even create several .ipa files with different
+                      export methods in the same build.
+                    env_key: BITRISE_DISTRIBUTION_METHOD
+                    type: selector
                     value_map:
-                      "":
-                        title: Distribution method
-                        summary: The export method used to create an .ipa file in
-                          your builds, stored as an Environment Variable. You can
-                          change this at any time, or even create several .ipa files
-                          with different export methods in the same build.
-                        env_key: BITRISE_DISTRIBUTION_METHOD
-                        type: selector
-                        value_map:
-                          ad-hoc:
-                            config: flutter-config-app-both
-                          app-store:
-                            config: flutter-config-app-both
-                          development:
-                            config: flutter-config-app-both
-                          enterprise:
-                            config: flutter-config-app-both
-              ios:
-                title: Project or Workspace path
-                summary: The location of your Xcode project or Xcode workspace files,
-                  stored as an Environment Variable. In your Workflows, you can specify
-                  paths relative to this path.
-                env_key: BITRISE_PROJECT_PATH
-                type: user_input
-                value_map:
-                  "":
-                    title: Scheme name
-                    summary: An Xcode scheme defines a collection of targets to build,
-                      a configuration to use when building, and a collection of tests
-                      to execute. Only shared schemes are detected automatically but
-                      you can use any scheme as a target on Bitrise. You can change
-                      the scheme at any time in your Env Vars.
-                    env_key: BITRISE_SCHEME
-                    type: user_input
-                    value_map:
-                      "":
-                        title: Distribution method
-                        summary: The export method used to create an .ipa file in
-                          your builds, stored as an Environment Variable. You can
-                          change this at any time, or even create several .ipa files
-                          with different export methods in the same build.
-                        env_key: BITRISE_DISTRIBUTION_METHOD
-                        type: selector
-                        value_map:
-                          ad-hoc:
-                            config: flutter-config-app-ios
-                          app-store:
-                            config: flutter-config-app-ios
-                          development:
-                            config: flutter-config-app-ios
-                          enterprise:
-                            config: flutter-config-app-ios
-              none:
-                config: flutter-config
-          "yes":
-            title: Platform
-            summary: The target platform for your first build. Your options are iOS,
-              Android, both, or neither. You can change this in your Env Vars at any
-              time.
-            type: selector
+                      ad-hoc:
+                        config: flutter-config-test-app-both
+                      app-store:
+                        config: flutter-config-test-app-both
+                      development:
+                        config: flutter-config-test-app-both
+                      enterprise:
+                        config: flutter-config-test-app-both
+          ios:
+            title: Project or Workspace path
+            summary: The location of your Xcode project or Xcode workspace files,
+              stored as an Environment Variable. In your Workflows, you can specify
+              paths relative to this path.
+            env_key: BITRISE_PROJECT_PATH
+            type: user_input
             value_map:
-              android:
-                config: flutter-config-test-app-android
-              both:
-                title: Project or Workspace path
-                summary: The location of your Xcode project or Xcode workspace files,
-                  stored as an Environment Variable. In your Workflows, you can specify
-                  paths relative to this path.
-                env_key: BITRISE_PROJECT_PATH
+              "":
+                title: Scheme name
+                summary: An Xcode scheme defines a collection of targets to build,
+                  a configuration to use when building, and a collection of tests
+                  to execute. Only shared schemes are detected automatically but you
+                  can use any scheme as a target on Bitrise. You can change the scheme
+                  at any time in your Env Vars.
+                env_key: BITRISE_SCHEME
                 type: user_input
                 value_map:
                   "":
-                    title: Scheme name
-                    summary: An Xcode scheme defines a collection of targets to build,
-                      a configuration to use when building, and a collection of tests
-                      to execute. Only shared schemes are detected automatically but
-                      you can use any scheme as a target on Bitrise. You can change
-                      the scheme at any time in your Env Vars.
-                    env_key: BITRISE_SCHEME
-                    type: user_input
+                    title: Distribution method
+                    summary: The export method used to create an .ipa file in your
+                      builds, stored as an Environment Variable. You can change this
+                      at any time, or even create several .ipa files with different
+                      export methods in the same build.
+                    env_key: BITRISE_DISTRIBUTION_METHOD
+                    type: selector
                     value_map:
-                      "":
-                        title: Distribution method
-                        summary: The export method used to create an .ipa file in
-                          your builds, stored as an Environment Variable. You can
-                          change this at any time, or even create several .ipa files
-                          with different export methods in the same build.
-                        env_key: BITRISE_DISTRIBUTION_METHOD
-                        type: selector
-                        value_map:
-                          ad-hoc:
-                            config: flutter-config-test-app-both
-                          app-store:
-                            config: flutter-config-test-app-both
-                          development:
-                            config: flutter-config-test-app-both
-                          enterprise:
-                            config: flutter-config-test-app-both
-              ios:
-                title: Project or Workspace path
-                summary: The location of your Xcode project or Xcode workspace files,
-                  stored as an Environment Variable. In your Workflows, you can specify
-                  paths relative to this path.
-                env_key: BITRISE_PROJECT_PATH
-                type: user_input
-                value_map:
-                  "":
-                    title: Scheme name
-                    summary: An Xcode scheme defines a collection of targets to build,
-                      a configuration to use when building, and a collection of tests
-                      to execute. Only shared schemes are detected automatically but
-                      you can use any scheme as a target on Bitrise. You can change
-                      the scheme at any time in your Env Vars.
-                    env_key: BITRISE_SCHEME
-                    type: user_input
-                    value_map:
-                      "":
-                        title: Distribution method
-                        summary: The export method used to create an .ipa file in
-                          your builds, stored as an Environment Variable. You can
-                          change this at any time, or even create several .ipa files
-                          with different export methods in the same build.
-                        env_key: BITRISE_DISTRIBUTION_METHOD
-                        type: selector
-                        value_map:
-                          ad-hoc:
-                            config: flutter-config-test-app-ios
-                          app-store:
-                            config: flutter-config-test-app-ios
-                          development:
-                            config: flutter-config-test-app-ios
-                          enterprise:
-                            config: flutter-config-test-app-ios
-              none:
-                config: flutter-config-test
+                      ad-hoc:
+                        config: flutter-config-test-app-ios
+                      app-store:
+                        config: flutter-config-test-app-ios
+                      development:
+                        config: flutter-config-test-app-ios
+                      enterprise:
+                        config: flutter-config-test-app-ios
   ionic:
     title: Directory of the Ionic config.xml file
     summary: The working directory of your Ionic project is where you store your config.xml
@@ -1146,33 +1030,7 @@ configs:
               - work_dir: $FASTLANE_WORK_DIR
           - deploy-to-bitrise-io@%s: {}
   flutter:
-    flutter-config: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
-      workflows:
-        primary:
-          steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-          - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - flutter-installer@%s:
-              inputs:
-              - is_update: "false"
-          - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
-          - cache-push@%s: {}
-    flutter-config-app-android: |
+    flutter-config-notest-app-android: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -1203,22 +1061,22 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-app-both: |
+          - deploy-to-bitrise-io@%s: {}
+    flutter-config-notest-app-both: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -1256,22 +1114,22 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-app-ios: |
+          - deploy-to-bitrise-io@%s: {}
+    flutter-config-notest-app-ios: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
@@ -1309,50 +1167,21 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
-    flutter-config-test: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
-      workflows:
-        primary:
-          steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-          - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
-          - flutter-installer@%s:
-              inputs:
-              - is_update: "false"
-          - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - flutter-test@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - deploy-to-bitrise-io@%s: {}
-          - cache-push@%s: {}
     flutter-config-test-app-android: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1387,24 +1216,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     flutter-config-test-app-both: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1446,24 +1275,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
     flutter-config-test-app-ios: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1505,24 +1334,24 @@ configs:
           - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
         primary:
+          description: |
+            Builds project and runs tests.
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
           - cache-pull@%s: {}
-          - flutter-analyze@%s:
-              inputs:
-              - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
           - flutter-test@%s:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
   ionic:
     default-ionic-config: |
       format_version: "%s"

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1058,8 +1058,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1111,8 +1110,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1164,8 +1162,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1213,8 +1210,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1272,8 +1268,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1331,8 +1326,7 @@ configs:
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - flutter-installer@%s:
               inputs:

--- a/scanners/flutter/const.go
+++ b/scanners/flutter/const.go
@@ -1,0 +1,9 @@
+package flutter
+
+const (
+	primaryWorkflowDescription = `Builds project and runs tests.
+
+Next steps:
+- Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
+`
+)

--- a/scanners/flutter/flutter.go
+++ b/scanners/flutter/flutter.go
@@ -16,7 +16,7 @@ import (
 	envmanModels "github.com/bitrise-io/envman/models"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -27,19 +27,14 @@ const (
 	defaultIOSConfiguration     = "Release"
 	projectLocationInputEnvKey  = "BITRISE_FLUTTER_PROJECT_LOCATION"
 	projectLocationInputTitle   = "Project location"
-	projectTypeInputEnvKey      = "BITRISE_FLUTTER_PROJECT_TYPE"
-	projectTypeInputTitle       = "Project Type"
-	testsInputTitle             = "Run tests found in the project"
 	platformInputTitle          = "Platform"
 	projectLocationInputSummary = "The path to your Flutter project, stored as an Environment Variable. In your Workflows, you can specify paths relative to this path. You can change this at any time."
-	testsInputSummary           = "Our Flutter Test Step can run the tests found in your project's repository."
 	platformInputSummary        = "The target platform for your first build. Your options are iOS, Android, both, or neither. You can change this in your Env Vars at any time."
 	installerUpdateFlutterKey   = "is_update"
 )
 
 var (
 	platforms = []string{
-		"none",
 		"android",
 		"ios",
 		"both",
@@ -249,74 +244,35 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 	flutterProjectLocationOption := models.NewOption(projectLocationInputTitle, projectLocationInputSummary, projectLocationInputEnvKey, models.TypeSelector)
 
 	for _, project := range scanner.projects {
+		var testKey string
 		if project.hasTest {
-			flutterProjectHasTestOption := models.NewOption(testsInputTitle, testsInputSummary, "", models.TypeSelector)
-			flutterProjectLocationOption.AddOption(project.path, flutterProjectHasTestOption)
+			testKey = "test"
+		} else {
+			testKey = "notest"
+		}
+		cfg := configName + "-" + testKey
 
-			for _, v := range []string{"yes", "no"} {
-				cfg := configName
-				if v == "yes" {
-					cfg += "-test"
-				}
+		if project.hasIosProject {
+			xcodeProjectPathOption := models.NewOption(ios.ProjectPathInputTitle, ios.ProjectPathInputSummary, ios.ProjectPathInputEnvKey, models.TypeSelector)
+			flutterProjectLocationOption.AddOption(project.path, xcodeProjectPathOption)
 
-				if project.hasIosProject || project.hasAndroidProject {
-					if project.hasIosProject {
-						projectPathOption := models.NewOption(ios.ProjectPathInputTitle, ios.ProjectPathInputSummary, ios.ProjectPathInputEnvKey, models.TypeSelector)
-						flutterProjectHasTestOption.AddOption(v, projectPathOption)
+			for xcodeWorkspacePath, schemes := range project.xcodeProjectPaths {
+				schemeOption := models.NewOption(ios.SchemeInputTitle, ios.SchemeInputSummary, ios.SchemeInputEnvKey, models.TypeSelector)
+				xcodeProjectPathOption.AddOption(xcodeWorkspacePath, schemeOption)
 
-						for xcodeWorkspacePath, schemes := range project.xcodeProjectPaths {
-							schemeOption := models.NewOption(ios.SchemeInputTitle, ios.SchemeInputSummary, ios.SchemeInputEnvKey, models.TypeSelector)
-							projectPathOption.AddOption(xcodeWorkspacePath, schemeOption)
+				for _, scheme := range schemes {
+					distributionMethodOption := models.NewOption(ios.DistributionMethodInputTitle, ios.DistributionMethodInputSummary, ios.DistributionMethodEnvKey, models.TypeSelector)
+					schemeOption.AddOption(scheme, distributionMethodOption)
 
-							for _, scheme := range schemes {
-								distributionMethodOption := models.NewOption(ios.DistributionMethodInputTitle, ios.DistributionMethodInputSummary, ios.DistributionMethodEnvKey, models.TypeSelector)
-								schemeOption.AddOption(scheme, distributionMethodOption)
-
-								for _, exportMethod := range ios.IosExportMethods {
-									configOption := models.NewConfigOption(cfg+"-app-"+getBuildablePlatform(project.hasAndroidProject, project.hasIosProject), nil)
-									distributionMethodOption.AddConfig(exportMethod, configOption)
-								}
-							}
-						}
-					} else {
+					for _, exportMethod := range ios.IosExportMethods {
 						configOption := models.NewConfigOption(cfg+"-app-"+getBuildablePlatform(project.hasAndroidProject, project.hasIosProject), nil)
-						flutterProjectHasTestOption.AddOption(v, configOption)
+						distributionMethodOption.AddConfig(exportMethod, configOption)
 					}
-				} else {
-					configOption := models.NewConfigOption(cfg, nil)
-					flutterProjectHasTestOption.AddOption(v, configOption)
 				}
 			}
 		} else {
-			cfg := configName
-
-			if project.hasIosProject || project.hasAndroidProject {
-				if project.hasIosProject {
-					projectPathOption := models.NewOption(ios.ProjectPathInputTitle, ios.ProjectPathInputSummary, ios.ProjectPathInputEnvKey, models.TypeSelector)
-					flutterProjectLocationOption.AddOption(project.path, projectPathOption)
-
-					for xcodeWorkspacePath, schemes := range project.xcodeProjectPaths {
-						schemeOption := models.NewOption(ios.SchemeInputTitle, ios.SchemeInputSummary, ios.SchemeInputEnvKey, models.TypeSelector)
-						projectPathOption.AddOption(xcodeWorkspacePath, schemeOption)
-
-						for _, scheme := range schemes {
-							distributionMethodOption := models.NewOption(ios.DistributionMethodInputTitle, ios.DistributionMethodInputSummary, ios.DistributionMethodEnvKey, models.TypeSelector)
-							schemeOption.AddOption(scheme, distributionMethodOption)
-
-							for _, exportMethod := range ios.IosExportMethods {
-								configOption := models.NewConfigOption(cfg+"-app-"+getBuildablePlatform(project.hasAndroidProject, project.hasIosProject), nil)
-								distributionMethodOption.AddConfig(exportMethod, configOption)
-							}
-						}
-					}
-				} else {
-					configOption := models.NewConfigOption(cfg+"-app-"+getBuildablePlatform(project.hasAndroidProject, project.hasIosProject), nil)
-					flutterProjectLocationOption.AddOption(project.path, configOption)
-				}
-			} else {
-				configOption := models.NewConfigOption(cfg, nil)
-				flutterProjectLocationOption.AddOption(project.path, configOption)
-			}
+			configOption := models.NewConfigOption(cfg+"-app-"+getBuildablePlatform(project.hasAndroidProject, project.hasIosProject), nil)
+			flutterProjectLocationOption.AddOption(project.path, configOption)
 		}
 	}
 
@@ -338,41 +294,29 @@ func getBuildablePlatform(hasAndroidProject, hasIosProject bool) string {
 func (Scanner) DefaultOptions() models.OptionNode {
 	flutterProjectLocationOption := models.NewOption(projectLocationInputTitle, projectLocationInputSummary, projectLocationInputEnvKey, models.TypeUserInput)
 
-	flutterProjectHasTestOption := models.NewOption(testsInputTitle, testsInputSummary, "", models.TypeSelector)
-	flutterProjectLocationOption.AddOption("", flutterProjectHasTestOption)
+	cfg := configName + "-test"
 
-	for _, v := range []string{"yes", "no"} {
-		cfg := configName
-		if v == "yes" {
-			cfg += "-test"
-		}
-		flutterPlatformOption := models.NewOption(platformInputTitle, platformInputSummary, "", models.TypeSelector)
-		flutterProjectHasTestOption.AddOption(v, flutterPlatformOption)
+	flutterPlatformOption := models.NewOption(platformInputTitle, platformInputSummary, "", models.TypeSelector)
+	flutterProjectLocationOption.AddOption("", flutterPlatformOption)
 
-		for _, platform := range platforms {
-			if platform != "none" {
-				if platform != "android" {
-					projectPathOption := models.NewOption(ios.ProjectPathInputTitle, ios.ProjectPathInputSummary, ios.ProjectPathInputEnvKey, models.TypeUserInput)
-					flutterPlatformOption.AddOption(platform, projectPathOption)
+	for _, platform := range platforms {
+		if platform != "android" {
+			projectPathOption := models.NewOption(ios.ProjectPathInputTitle, ios.ProjectPathInputSummary, ios.ProjectPathInputEnvKey, models.TypeUserInput)
+			flutterPlatformOption.AddOption(platform, projectPathOption)
 
-					schemeOption := models.NewOption(ios.SchemeInputTitle, ios.SchemeInputSummary, ios.SchemeInputEnvKey, models.TypeUserInput)
-					projectPathOption.AddOption("", schemeOption)
+			schemeOption := models.NewOption(ios.SchemeInputTitle, ios.SchemeInputSummary, ios.SchemeInputEnvKey, models.TypeUserInput)
+			projectPathOption.AddOption("", schemeOption)
 
-					distributionMethodOption := models.NewOption(ios.DistributionMethodInputTitle, ios.DistributionMethodInputSummary, ios.DistributionMethodEnvKey, models.TypeSelector)
-					schemeOption.AddOption("", distributionMethodOption)
+			distributionMethodOption := models.NewOption(ios.DistributionMethodInputTitle, ios.DistributionMethodInputSummary, ios.DistributionMethodEnvKey, models.TypeSelector)
+			schemeOption.AddOption("", distributionMethodOption)
 
-					for _, exportMethod := range ios.IosExportMethods {
-						configOption := models.NewConfigOption(cfg+"-app-"+platform, nil)
-						distributionMethodOption.AddConfig(exportMethod, configOption)
-					}
-				} else {
-					configOption := models.NewConfigOption(cfg+"-app-"+platform, nil)
-					flutterPlatformOption.AddConfig(platform, configOption)
-				}
-			} else {
-				configOption := models.NewConfigOption(cfg, nil)
-				flutterPlatformOption.AddConfig(platform, configOption)
+			for _, exportMethod := range ios.IosExportMethods {
+				configOption := models.NewConfigOption(cfg+"-app-"+platform, nil)
+				distributionMethodOption.AddConfig(exportMethod, configOption)
 			}
+		} else {
+			configOption := models.NewConfigOption(cfg+"-app-"+platform, nil)
+			flutterPlatformOption.AddConfig(platform, configOption)
 		}
 	}
 
@@ -380,34 +324,40 @@ func (Scanner) DefaultOptions() models.OptionNode {
 }
 
 // Configs ...
-func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
-	return scanner.DefaultConfigs()
+func (scanner *Scanner) Configs(isPrivateRepository bool) (models.BitriseConfigMap, error) {
+	return generateConfigMap(isPrivateRepository)
 }
 
 // DefaultConfigs ...
 func (scanner Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
+	return generateConfigMap(false)
+}
+
+func generateConfigMap(isPrivateRepository bool) (models.BitriseConfigMap, error) {
 	configs := models.BitriseConfigMap{}
 
 	for _, variant := range []struct {
 		configID string
 		test     bool
-		deploy   bool
 		platform string
 	}{
-		{test: false, deploy: false, configID: configName},
-		{test: true, deploy: false, configID: configName + "-test"},
-		{test: false, deploy: true, platform: "both", configID: configName + "-app-both"},
-		{test: true, deploy: true, platform: "both", configID: configName + "-test-app-both"},
-		{test: false, deploy: true, platform: "android", configID: configName + "-app-android"},
-		{test: true, deploy: true, platform: "android", configID: configName + "-test-app-android"},
-		{test: false, deploy: true, platform: "ios", configID: configName + "-app-ios"},
-		{test: true, deploy: true, platform: "ios", configID: configName + "-test-app-ios"},
+		{test: false, platform: "both", configID: configName + "-notest-app-both"},
+		{test: true, platform: "both", configID: configName + "-test-app-both"},
+		{test: false, platform: "android", configID: configName + "-notest-app-android"},
+		{test: true, platform: "android", configID: configName + "-test-app-android"},
+		{test: false, platform: "ios", configID: configName + "-notest-app-ios"},
+		{test: true, platform: "ios", configID: configName + "-test-app-ios"},
 	} {
 		configBuilder := models.NewDefaultConfigBuilder()
 
 		// primary
+		configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryWorkflowDescription)
 
-		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(false)...)
+		prepareSteps := steps.DefaultPrepareStepListV2(steps.PrepareListParams{
+			ShouldIncludeCache:       false,
+			ShouldIncludeActivateSSH: isPrivateRepository,
+		})
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, prepareSteps...)
 
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.FlutterInstallStepListItem(
 			envmanModels.EnvironmentItemModel{installerUpdateFlutterKey: "false"},
@@ -416,59 +366,52 @@ func (scanner Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 		// cache-pull is after flutter-installer, to prevent removal of pub system cache
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CachePullStepListItem())
 
-		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.FlutterAnalyzeStepListItem(
-			envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
-		))
-
 		if variant.test {
 			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.FlutterTestStepListItem(
 				envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
 			))
 		}
 
-		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(true)...)
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(true)...)
 
 		// deploy
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepList(false)...)
 
-		if variant.deploy {
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepList(false)...)
-
-			if variant.platform != "android" {
-				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
-			}
-
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterInstallStepListItem(
-				envmanModels.EnvironmentItemModel{installerUpdateFlutterKey: "false"},
-			))
-
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CachePullStepListItem())
-
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterAnalyzeStepListItem(
-				envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
-			))
-
-			if variant.test {
-				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterTestStepListItem(
-					envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
-				))
-			}
-
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterBuildStepListItem(
-				envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
-				envmanModels.EnvironmentItemModel{platformInputKey: variant.platform},
-			))
-
-			if variant.platform != "android" {
-				configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveStepListItem(
-					envmanModels.EnvironmentItemModel{ios.ProjectPathInputKey: "$" + ios.ProjectPathInputEnvKey},
-					envmanModels.EnvironmentItemModel{ios.SchemeInputKey: "$" + ios.SchemeInputEnvKey},
-					envmanModels.EnvironmentItemModel{ios.DistributionMethodInputKey: "$" + ios.DistributionMethodEnvKey},
-					envmanModels.EnvironmentItemModel{ios.ConfigurationInputKey: defaultIOSConfiguration},
-				))
-			}
-
-			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepList(true)...)
+		if variant.platform != "android" {
+			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
 		}
+
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterInstallStepListItem(
+			envmanModels.EnvironmentItemModel{installerUpdateFlutterKey: "false"},
+		))
+
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CachePullStepListItem())
+
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterAnalyzeStepListItem(
+			envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
+		))
+
+		if variant.test {
+			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterTestStepListItem(
+				envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
+			))
+		}
+
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterBuildStepListItem(
+			envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
+			envmanModels.EnvironmentItemModel{platformInputKey: variant.platform},
+		))
+
+		if variant.platform != "android" {
+			configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.XcodeArchiveStepListItem(
+				envmanModels.EnvironmentItemModel{ios.ProjectPathInputKey: "$" + ios.ProjectPathInputEnvKey},
+				envmanModels.EnvironmentItemModel{ios.SchemeInputKey: "$" + ios.SchemeInputEnvKey},
+				envmanModels.EnvironmentItemModel{ios.DistributionMethodInputKey: "$" + ios.DistributionMethodEnvKey},
+				envmanModels.EnvironmentItemModel{ios.ConfigurationInputKey: defaultIOSConfiguration},
+			))
+		}
+
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepList(true)...)
 
 		config, err := configBuilder.Generate(scannerName)
 		if err != nil {

--- a/scanners/flutter/flutter.go
+++ b/scanners/flutter/flutter.go
@@ -330,7 +330,7 @@ func (scanner *Scanner) Configs(isPrivateRepository bool) (models.BitriseConfigM
 
 // DefaultConfigs ...
 func (scanner Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
-	return generateConfigMap(false)
+	return generateConfigMap(true)
 }
 
 func generateConfigMap(isPrivateRepository bool) (models.BitriseConfigMap, error) {


### PR DESCRIPTION
### Context

Update the primary Flutter workflow creation by removing some steps and simplifying detection.

### Changes

#### High-level overview

- Remove Script step in all possible cases
- Remove Flutter Analyze step in all possible cases
- Add primary workflow description
- Don't ask the user about the presence of tests. This information is detected by the scanner and we can insert/omit the Flutter Test step just like before.
- Don't insert SSH key step if the Git repo is public (as it's not needed for public repos)
- Swap Cache Push and Deploy to Bitrise.io steps

#### Details

See my line-by-line comments in the diff view

