### PR TITLE
Update Flutter deploy workflow

### DIFF
--- a/_tests/integration/flutter_test.go
+++ b/_tests/integration/flutter_test.go
@@ -82,13 +82,12 @@ var flutterSampleAppVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -101,15 +100,13 @@ var flutterSampleAppVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -122,15 +119,13 @@ var flutterSampleAppVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -143,14 +138,13 @@ var flutterSampleAppVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -164,16 +158,14 @@ var flutterSampleAppVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -187,16 +179,14 @@ var flutterSampleAppVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -217,39 +207,7 @@ var flutterSampleAppResultYML = fmt.Sprintf(`options:
     type: selector
     value_map:
       .:
-        title: Project or Workspace path
-        summary: The location of your Xcode project or Xcode workspace files, stored
-          as an Environment Variable. In your Workflows, you can specify paths relative
-          to this path.
-        env_key: BITRISE_PROJECT_PATH
-        type: selector
-        value_map:
-          ios/Runner.xcworkspace:
-            title: Scheme name
-            summary: An Xcode scheme defines a collection of targets to build, a configuration
-              to use when building, and a collection of tests to execute. Only shared
-              schemes are detected automatically but you can use any scheme as a target
-              on Bitrise. You can change the scheme at any time in your Env Vars.
-            env_key: BITRISE_SCHEME
-            type: selector
-            value_map:
-              Runner:
-                title: Distribution method
-                summary: The export method used to create an .ipa file in your builds,
-                  stored as an Environment Variable. You can change this at any time,
-                  or even create several .ipa files with different export methods
-                  in the same build.
-                env_key: BITRISE_DISTRIBUTION_METHOD
-                type: selector
-                value_map:
-                  ad-hoc:
-                    config: flutter-config-test-app-both
-                  app-store:
-                    config: flutter-config-test-app-both
-                  development:
-                    config: flutter-config-test-app-both
-                  enterprise:
-                    config: flutter-config-test-app-both
+        config: flutter-config-test-app-both
 configs:
   flutter:
     flutter-config-notest-app-android: |
@@ -263,12 +221,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
@@ -280,8 +241,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: android
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -308,12 +269,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -326,14 +290,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -360,12 +318,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -378,14 +339,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -412,12 +367,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
@@ -432,8 +390,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: android
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -463,12 +421,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -484,14 +445,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -521,12 +476,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -542,14 +500,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -579,13 +531,12 @@ var flutterSamplePackageVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -598,15 +549,13 @@ var flutterSamplePackageVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -619,15 +568,13 @@ var flutterSamplePackageVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -640,14 +587,13 @@ var flutterSamplePackageVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -661,16 +607,14 @@ var flutterSamplePackageVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -684,16 +628,14 @@ var flutterSamplePackageVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -728,12 +670,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
@@ -745,8 +690,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: android
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -773,12 +718,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -791,14 +739,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -825,12 +767,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -843,14 +788,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -877,12 +816,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
@@ -897,8 +839,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: android
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -928,12 +870,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -949,14 +894,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -986,12 +925,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1007,14 +949,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1044,13 +980,12 @@ var flutterSamplePluginVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1063,15 +998,13 @@ var flutterSamplePluginVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1084,15 +1017,13 @@ var flutterSamplePluginVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1105,14 +1036,13 @@ var flutterSamplePluginVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1126,16 +1056,14 @@ var flutterSamplePluginVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1149,16 +1077,14 @@ var flutterSamplePluginVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1181,39 +1107,7 @@ var flutterSamplePluginResultYML = fmt.Sprintf(`options:
       .:
         config: flutter-config-notest-app-android
       example:
-        title: Project or Workspace path
-        summary: The location of your Xcode project or Xcode workspace files, stored
-          as an Environment Variable. In your Workflows, you can specify paths relative
-          to this path.
-        env_key: BITRISE_PROJECT_PATH
-        type: selector
-        value_map:
-          example/ios/Runner.xcworkspace:
-            title: Scheme name
-            summary: An Xcode scheme defines a collection of targets to build, a configuration
-              to use when building, and a collection of tests to execute. Only shared
-              schemes are detected automatically but you can use any scheme as a target
-              on Bitrise. You can change the scheme at any time in your Env Vars.
-            env_key: BITRISE_SCHEME
-            type: selector
-            value_map:
-              Runner:
-                title: Distribution method
-                summary: The export method used to create an .ipa file in your builds,
-                  stored as an Environment Variable. You can change this at any time,
-                  or even create several .ipa files with different export methods
-                  in the same build.
-                env_key: BITRISE_DISTRIBUTION_METHOD
-                type: selector
-                value_map:
-                  ad-hoc:
-                    config: flutter-config-test-app-both
-                  app-store:
-                    config: flutter-config-test-app-both
-                  development:
-                    config: flutter-config-test-app-both
-                  enterprise:
-                    config: flutter-config-test-app-both
+        config: flutter-config-test-app-both
 configs:
   flutter:
     flutter-config-notest-app-android: |
@@ -1227,12 +1121,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
@@ -1244,8 +1141,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: android
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1272,12 +1169,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1290,14 +1190,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1324,12 +1218,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1342,14 +1239,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1376,12 +1267,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
@@ -1396,8 +1290,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: android
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1427,12 +1321,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1448,14 +1345,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1485,12 +1376,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1506,14 +1400,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.

--- a/_tests/integration/flutter_test.go
+++ b/_tests/integration/flutter_test.go
@@ -222,7 +222,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -270,7 +272,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -290,6 +294,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -319,7 +324,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -339,6 +346,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -368,7 +376,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -422,7 +432,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -445,6 +457,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -477,7 +490,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -500,6 +515,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -671,7 +687,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -719,7 +737,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -739,6 +759,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -768,7 +789,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -788,6 +811,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -817,7 +841,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -871,7 +897,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -894,6 +922,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -926,7 +955,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -949,6 +980,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -1122,7 +1154,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1170,7 +1204,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1190,6 +1226,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -1219,7 +1256,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1239,6 +1278,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -1268,7 +1308,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1322,7 +1364,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1345,6 +1389,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -1377,7 +1422,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1400,6 +1447,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -93,13 +93,12 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -112,15 +111,13 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -133,15 +130,13 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -154,14 +149,13 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -175,16 +169,14 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -198,16 +190,14 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FlutterInstallVersion,
 	steps.CachePullVersion,
 	steps.FlutterAnalyzeVersion,
 	steps.FlutterTestVersion,
 	steps.FlutterBuildVersion,
-	steps.XcodeArchiveVersion,
-	steps.DeployToBitriseIoVersion,
 	steps.CachePushVersion,
+	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -410,75 +400,9 @@ var customConfigResultYML = fmt.Sprintf(`options:
           android:
             config: flutter-config-test-app-android
           both:
-            title: Project or Workspace path
-            summary: The location of your Xcode project or Xcode workspace files,
-              stored as an Environment Variable. In your Workflows, you can specify
-              paths relative to this path.
-            env_key: BITRISE_PROJECT_PATH
-            type: user_input
-            value_map:
-              "":
-                title: Scheme name
-                summary: An Xcode scheme defines a collection of targets to build,
-                  a configuration to use when building, and a collection of tests
-                  to execute. Only shared schemes are detected automatically but you
-                  can use any scheme as a target on Bitrise. You can change the scheme
-                  at any time in your Env Vars.
-                env_key: BITRISE_SCHEME
-                type: user_input
-                value_map:
-                  "":
-                    title: Distribution method
-                    summary: The export method used to create an .ipa file in your
-                      builds, stored as an Environment Variable. You can change this
-                      at any time, or even create several .ipa files with different
-                      export methods in the same build.
-                    env_key: BITRISE_DISTRIBUTION_METHOD
-                    type: selector
-                    value_map:
-                      ad-hoc:
-                        config: flutter-config-test-app-both
-                      app-store:
-                        config: flutter-config-test-app-both
-                      development:
-                        config: flutter-config-test-app-both
-                      enterprise:
-                        config: flutter-config-test-app-both
+            config: flutter-config-test-app-both
           ios:
-            title: Project or Workspace path
-            summary: The location of your Xcode project or Xcode workspace files,
-              stored as an Environment Variable. In your Workflows, you can specify
-              paths relative to this path.
-            env_key: BITRISE_PROJECT_PATH
-            type: user_input
-            value_map:
-              "":
-                title: Scheme name
-                summary: An Xcode scheme defines a collection of targets to build,
-                  a configuration to use when building, and a collection of tests
-                  to execute. Only shared schemes are detected automatically but you
-                  can use any scheme as a target on Bitrise. You can change the scheme
-                  at any time in your Env Vars.
-                env_key: BITRISE_SCHEME
-                type: user_input
-                value_map:
-                  "":
-                    title: Distribution method
-                    summary: The export method used to create an .ipa file in your
-                      builds, stored as an Environment Variable. You can change this
-                      at any time, or even create several .ipa files with different
-                      export methods in the same build.
-                    env_key: BITRISE_DISTRIBUTION_METHOD
-                    type: selector
-                    value_map:
-                      ad-hoc:
-                        config: flutter-config-test-app-ios
-                      app-store:
-                        config: flutter-config-test-app-ios
-                      development:
-                        config: flutter-config-test-app-ios
-                      enterprise:
-                        config: flutter-config-test-app-ios
+            config: flutter-config-test-app-ios
   ionic:
     title: Directory of the Ionic config.xml file
     summary: The working directory of your Ionic project is where you store your config.xml
@@ -1032,12 +956,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
@@ -1049,8 +976,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: android
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1077,12 +1004,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1095,14 +1025,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1129,12 +1053,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1147,14 +1074,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1181,12 +1102,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - flutter-installer@%s:
               inputs:
               - is_update: "false"
@@ -1201,8 +1125,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: android
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1232,12 +1156,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1253,14 +1180,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.
@@ -1290,12 +1211,15 @@ configs:
         workflow: primary
       workflows:
         deploy:
+          description: |
+            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            Next steps:
+            - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+            - Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
           steps:
-          - activate-ssh-key@%s:
-              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - flutter-installer@%s:
               inputs:
@@ -1311,14 +1235,8 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
-          - xcode-archive@%s:
-              inputs:
-              - project_path: $BITRISE_PROJECT_PATH
-              - scheme: $BITRISE_SCHEME
-              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
-              - configuration: Release
-          - deploy-to-bitrise-io@%s: {}
           - cache-push@%s: {}
+          - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
             Builds project and runs tests.

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -957,7 +957,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1005,7 +1007,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1025,6 +1029,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -1054,7 +1059,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1074,6 +1081,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -1103,7 +1111,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1157,7 +1167,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1180,6 +1192,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: both
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
@@ -1212,7 +1225,9 @@ configs:
       workflows:
         deploy:
           description: |
-            Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+            Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+            If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
             Next steps:
             - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
@@ -1235,6 +1250,7 @@ configs:
               inputs:
               - project_location: $BITRISE_FLUTTER_PROJECT_LOCATION
               - platform: ios
+              - ios_output_type: archive
           - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:

--- a/scanners/flutter/const.go
+++ b/scanners/flutter/const.go
@@ -7,7 +7,9 @@ Next steps:
 - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
 `
 
-	deployWorkflowDescription = `Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+	deployWorkflowDescription = `Builds and deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+If you build for iOS, make sure to set up code signing secrets on Bitrise for a successful build.
 
 Next steps:
 - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.

--- a/scanners/flutter/const.go
+++ b/scanners/flutter/const.go
@@ -6,4 +6,11 @@ const (
 Next steps:
 - Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html).
 `
+
+	deployWorkflowDescription = `Deploys app using [Deploy to bitrise.io Step](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html#deploying-a-flutter-app).
+
+Next steps:
+- Check out [Getting started with Flutter apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps.html) for signing and deployment options.
+- Check out the [Code signing guide](https://devcenter.bitrise.io/en/code-signing.html) for iOS and Android
+`
 )

--- a/scanners/flutter/flutter.go
+++ b/scanners/flutter/flutter.go
@@ -23,12 +23,14 @@ const (
 	scannerName                 = "flutter"
 	configName                  = "flutter-config"
 	projectLocationInputKey     = "project_location"
-	platformInputKey            = "platform"
 	projectLocationInputEnvKey  = "BITRISE_FLUTTER_PROJECT_LOCATION"
 	projectLocationInputTitle   = "Project location"
-	platformInputTitle          = "Platform"
 	projectLocationInputSummary = "The path to your Flutter project, stored as an Environment Variable. In your Workflows, you can specify paths relative to this path. You can change this at any time."
+	platformInputKey            = "platform"
+	platformInputTitle          = "Platform"
 	platformInputSummary        = "The target platform for your first build. Your options are iOS, Android, both, or neither. You can change this in your Env Vars at any time."
+	iosOutputTypeKey            = "ios_output_type"
+	iosOutputTypeArchive        = "archive"
 	installerUpdateFlutterKey   = "is_update"
 )
 
@@ -364,10 +366,14 @@ func (scanner Scanner) generateConfigMap(isPrivateRepository bool) (models.Bitri
 			))
 		}
 
-		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterBuildStepListItem(
-			envmanModels.EnvironmentItemModel{projectLocationInputKey: "$" + projectLocationInputEnvKey},
-			envmanModels.EnvironmentItemModel{platformInputKey: variant.platform},
-		))
+		flutterBuildInputs := []envmanModels.EnvironmentItemModel{
+			{projectLocationInputKey: "$" + projectLocationInputEnvKey},
+			{platformInputKey: variant.platform},
+		}
+		if variant.platform != "android" {
+			flutterBuildInputs = append(flutterBuildInputs, envmanModels.EnvironmentItemModel{iosOutputTypeKey: iosOutputTypeArchive})
+		}
+		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.FlutterBuildStepListItem(flutterBuildInputs...))
 
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, deploySteps...)
 


### PR DESCRIPTION
### Context

Updating and simplifying the Flutter workflows. Follow-up to #223 

### Changes

- Remove Xcode archive step from the workflow as the Flutter build command has this functionality now for a while
- Set `ios_build_type` to `archive` in the Flutter build step if platform is `ios` or `both` to build an xcarchive
- Remove empty Script step
- Remove scanner options related to the Xcode archive step, such as the distribution method. These options are no longer needed, because the Xcode Archive step is removed, plus the deploy workflow needs some manual configuration anyway before the first successful build
- Add workflow description