### PR TITLE
Fix missing Ruby during react-native Podfile detection

### DIFF
--- a/scanners/ios/podfile.go
+++ b/scanners/ios/podfile.go
@@ -69,9 +69,8 @@ end
 	}
 
 	envs := []string{fmt.Sprintf("PODFILE_PATH=%s", absPodfilePth)}
-	podfileDir := filepath.Dir(absPodfilePth)
 
-	out, err := runRubyScriptForOutput(rubyScriptContent, gemfileContent, podfileDir, envs)
+	out, err := runRubyScriptForOutput(rubyScriptContent, gemfileContent, envs)
 	if err != nil {
 		return map[string]string{}, fmt.Errorf("ruby script failed, error: %s", err)
 	}
@@ -161,9 +160,8 @@ end
 	}
 
 	envs := []string{fmt.Sprintf("PODFILE_PATH=%s", absPodfilePth)}
-	podfileDir := filepath.Dir(absPodfilePth)
 
-	out, err := runRubyScriptForOutput(rubyScriptContent, gemfileContent, podfileDir, envs)
+	out, err := runRubyScriptForOutput(rubyScriptContent, gemfileContent, envs)
 	if err != nil {
 		return "", fmt.Errorf("ruby script failed, error: %s", err)
 	}

--- a/scanners/ios/podfile.go
+++ b/scanners/ios/podfile.go
@@ -65,14 +65,14 @@ end
 
 	absPodfilePth, err := filepath.Abs(podfileParser.podfilePth)
 	if err != nil {
-		return map[string]string{}, fmt.Errorf("failed to expand path (%s), error: %s", podfileParser.podfilePth, err)
+		return map[string]string{}, fmt.Errorf("failed to expand path (%s): %s", podfileParser.podfilePth, err)
 	}
 
 	envs := []string{fmt.Sprintf("PODFILE_PATH=%s", absPodfilePth)}
 
 	out, err := runRubyScriptForOutput(rubyScriptContent, gemfileContent, envs)
 	if err != nil {
-		return map[string]string{}, fmt.Errorf("ruby script failed, error: %s", err)
+		return map[string]string{}, fmt.Errorf("ruby script failed: %s", err)
 	}
 
 	if out == "" {
@@ -86,11 +86,11 @@ end
 
 	var targetDefinitionOutput targetDefinitionOutputModel
 	if err := json.Unmarshal([]byte(out), &targetDefinitionOutput); err != nil {
-		return map[string]string{}, fmt.Errorf("failed to parse target definition output, error: %s", err)
+		return map[string]string{}, fmt.Errorf("failed to parse target definition output: %s", err)
 	}
 
 	if podfileParser.shouldRaiseReadDefinitionError(targetDefinitionOutput.Error) {
-		return map[string]string{}, fmt.Errorf("failed to read target defintion map, error: %s", targetDefinitionOutput.Error)
+		return map[string]string{}, fmt.Errorf("failed to read target definition map: %s", targetDefinitionOutput.Error)
 	}
 
 	return targetDefinitionOutput.Data, nil
@@ -114,7 +114,7 @@ func (podfileParser podfileParser) shouldRaiseReadDefinitionError(err string) bo
 func (podfileParser podfileParser) getUserDefinedProjectRelavtivePath(cocoapodsVersion string) (string, error) {
 	targetProjectMap, err := podfileParser.getTargetDefinitionProjectMap(cocoapodsVersion)
 	if err != nil {
-		return "", fmt.Errorf("failed to get target definition map, error: %s", err)
+		return "", fmt.Errorf("failed to get target definition map: %s", err)
 	}
 
 	for target, project := range targetProjectMap {
@@ -156,14 +156,14 @@ end
 `
 	absPodfilePth, err := filepath.Abs(podfileParser.podfilePth)
 	if err != nil {
-		return "", fmt.Errorf("failed to expand path (%s), error: %s", podfileParser.podfilePth, err)
+		return "", fmt.Errorf("failed to expand path (%s): %s", podfileParser.podfilePth, err)
 	}
 
 	envs := []string{fmt.Sprintf("PODFILE_PATH=%s", absPodfilePth)}
 
 	out, err := runRubyScriptForOutput(rubyScriptContent, gemfileContent, envs)
 	if err != nil {
-		return "", fmt.Errorf("ruby script failed, error: %s", err)
+		return "", fmt.Errorf("ruby script failed: %s", err)
 	}
 
 	if out == "" {
@@ -177,11 +177,11 @@ end
 
 	var workspacePathOutput workspacePathOutputModel
 	if err := json.Unmarshal([]byte(out), &workspacePathOutput); err != nil {
-		return "", fmt.Errorf("failed to parse workspace path output, error: %s", err)
+		return "", fmt.Errorf("failed to parse workspace path output: %s", err)
 	}
 
 	if podfileParser.shouldRaiseReadDefinitionError(workspacePathOutput.Error) {
-		return "", fmt.Errorf("failed to read workspace path, error: %s", workspacePathOutput.Error)
+		return "", fmt.Errorf("failed to read workspace path: %s", workspacePathOutput.Error)
 	}
 
 	return workspacePathOutput.Data, nil
@@ -211,19 +211,19 @@ func (podfileParser podfileParser) GetWorkspaceProjectMap(projects []string) (ma
 
 	projectRelPth, err := podfileParser.getUserDefinedProjectRelavtivePath(cocoapodsVersion)
 	if err != nil {
-		return map[string]string{}, fmt.Errorf("failed to get user defined project path, error: %s", err)
+		return map[string]string{}, fmt.Errorf("failed to get user defined project path: %s", err)
 	}
 
 	if projectRelPth == "" {
 		projects, err := pathutil.FilterPaths(projects, pathutil.InDirectoryFilter(podfileDir, true))
 		if err != nil {
-			return map[string]string{}, fmt.Errorf("failed to filter projects, error: %s", err)
+			return map[string]string{}, fmt.Errorf("failed to filter projects: %s", err)
 		}
 
 		if len(projects) == 0 {
-			return map[string]string{}, errors.New("failed to determin workspace - project mapping: no explicit project specified and no project found in the Podfile's directory")
+			return map[string]string{}, errors.New("failed to determine workspace - project mapping: no explicit project specified and no project found in the Podfile's directory")
 		} else if len(projects) > 1 {
-			return map[string]string{}, errors.New("failed to determin workspace - project mapping: no explicit project specified and more than one project found in the Podfile's directory")
+			return map[string]string{}, errors.New("failed to determine workspace - project mapping: no explicit project specified and more than one project found in the Podfile's directory")
 		}
 
 		projectRelPth = filepath.Base(projects[0])
@@ -231,14 +231,14 @@ func (podfileParser podfileParser) GetWorkspaceProjectMap(projects []string) (ma
 	projectPth := filepath.Join(podfileDir, projectRelPth)
 
 	if exist, err := pathutil.IsPathExists(projectPth); err != nil {
-		return map[string]string{}, fmt.Errorf("failed to check if path (%s) exists, error: %s", projectPth, err)
+		return map[string]string{}, fmt.Errorf("failed to check if path (%s) exists: %s", projectPth, err)
 	} else if !exist {
 		return map[string]string{}, fmt.Errorf("project not found at: %s", projectPth)
 	}
 
 	workspaceRelPth, err := podfileParser.getUserDefinedWorkspaceRelativePath(cocoapodsVersion)
 	if err != nil {
-		return map[string]string{}, fmt.Errorf("failed to get user defined workspace path, error: %s", err)
+		return map[string]string{}, fmt.Errorf("failed to get user defined workspace path: %s", err)
 	}
 
 	if workspaceRelPth == "" {
@@ -284,7 +284,7 @@ func (podfileParser podfileParser) cocoapodsVersion(podfileLockPth string) (stri
 func (podfileParser podfileParser) fixPodfileQuotation(podfilePth string) error {
 	podfileContent, err := fileutil.ReadStringFromFile(podfilePth)
 	if err != nil {
-		return fmt.Errorf("failed to read podfile (%s), error: %s", podfilePth, err)
+		return fmt.Errorf("failed to read podfile (%s): %s", podfilePth, err)
 	}
 
 	podfileContent = strings.Replace(podfileContent, `‘`, `'`, -1)
@@ -293,7 +293,7 @@ func (podfileParser podfileParser) fixPodfileQuotation(podfilePth string) error 
 	podfileContent = strings.Replace(podfileContent, `”`, `"`, -1)
 
 	if err := fileutil.WriteStringToFile(podfilePth, podfileContent); err != nil {
-		return fmt.Errorf("failed to apply Podfile quotation fix, error: %s", err)
+		return fmt.Errorf("failed to apply Podfile quotation fix: %s", err)
 	}
 
 	return nil

--- a/scanners/ios/rubyscript.go
+++ b/scanners/ios/rubyscript.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
-func runRubyScriptForOutput(scriptContent, gemfileContent, inDir string, withEnvs []string) (string, error) {
+func runRubyScriptForOutput(scriptContent, gemfileContent string, withEnvs []string) (string, error) {
 	tmpDir, err := pathutil.NormalizedOSTempDirPath("__bitrise-init__")
 	if err != nil {
 		return "", err
@@ -32,10 +32,7 @@ func runRubyScriptForOutput(scriptContent, gemfileContent, inDir string, withEnv
 		}
 
 		cmd := command.New("bundle", "install")
-
-		if inDir != "" {
-			cmd.SetDir(inDir)
-		}
+		cmd.SetDir(tmpDir)
 
 		withEnvs = append(withEnvs, "BUNDLE_GEMFILE="+gemfilePth)
 		cmd.AppendEnvs(withEnvs...)
@@ -62,9 +59,9 @@ func runRubyScriptForOutput(scriptContent, gemfileContent, inDir string, withEnv
 		cmd = command.New("ruby", rubyScriptPth)
 	}
 
-	if inDir != "" {
-		cmd.SetDir(inDir)
-	}
+	// Set the temp dir as working dir, so the project defined `.ruby-version` does not cause ruby resolution to fail:
+	// [ ... ] ruby script failed, error: rbenv: version `2.7.4' is not installed (set by /[ ... ]/MyTestApp/.ruby-version)
+	cmd.SetDir(tmpDir)
 
 	if len(withEnvs) > 0 {
 		cmd.AppendEnvs(withEnvs...)

--- a/scanners/ios/rubyscript_test.go
+++ b/scanners/ios/rubyscript_test.go
@@ -17,7 +17,7 @@ puts "#{{ :test_key => 'test_value' }.to_json}"
 `
 
 	expectedOut := "{\"test_key\":\"test_value\"}"
-	actualOut, err := runRubyScriptForOutput(rubyScriptContent, gemfileContent, "", []string{})
+	actualOut, err := runRubyScriptForOutput(rubyScriptContent, gemfileContent, []string{})
 	require.NoError(t, err)
 	require.Equal(t, expectedOut, actualOut)
 }


### PR DESCRIPTION
Resolves: https://bitrise.atlassian.net/browse/STEP-1742


### Context

Set the temp dir as working dir, so the project defined `.ruby-version` does not cause ruby resolution to fail:

``` [ ... ] ruby script failed, error: rbenv: version `2.7.4' is not installed (set by /[ ... ]/MyTestApp/.ruby-version)```

### Changes
- Removed *runRubyScriptForOutput* _inDir_ parameter
- Improved error messages
	