### PR TITLE
Separate android project parsing

### DIFF
--- a/scanner/config_test.go
+++ b/scanner/config_test.go
@@ -28,7 +28,7 @@ func Test_scannerOutput_AddErrors(t *testing.T) {
 	}{
 		{
 			name: "Mapped error",
-			args: args{tag: optionsFailedTag, errs: []string{"No Gradle Wrapper (gradlew) found."}},
+			args: args{tag: detectPlatformFailedTag, errs: []string{"No Gradle Wrapper (gradlew) found."}},
 			want: scannerOutput{errorsWithRecommendation: []models.ErrorWithRecommendations{{Error: "No Gradle Wrapper (gradlew) found.", Recommendations: GradlewNotFoundRecommendation}}},
 		},
 		{

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -69,7 +69,9 @@ func availableScanners() (scannerNames []string) {
 func newDetectPlatformFailedMatcher() *errormapper.PatternErrorMatcher {
 	return newPatternErrorMatcher(
 		newDetectPlatformFailedGenericDetail,
-		nil,
+		map[string]errormapper.DetailedErrorBuilder{
+			`No Gradle Wrapper \(gradlew\) found\.`: newGradlewNotFoundDetail,
+		},
 	)
 }
 
@@ -85,10 +87,9 @@ func newOptionsFailedMatcher() *errormapper.PatternErrorMatcher {
 	return newPatternErrorMatcher(
 		newOptionsFailedGenericDetail,
 		map[string]errormapper.DetailedErrorBuilder{
-			`No Gradle Wrapper \(gradlew\) found\.`:                                                                                 newGradlewNotFoundDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nThe app\.json file needs to contain:`:                             newAppJSONIssueDetail,
 			`app\.json file \((.+)\) missing or empty (.+) entry\nIf the project uses Expo Kit the app.json file needs to contain:`: newExpoAppJSONIssueDetail,
-			`Cordova config.xml not found.`:                                                                                         newIonicCapacitorNotSupportedIssueDetail,
+			`Cordova config.xml not found.`: newIonicCapacitorNotSupportedIssueDetail,
 		},
 	)
 }

--- a/scanner/errors_test.go
+++ b/scanner/errors_test.go
@@ -30,8 +30,8 @@ func Test_mapRecommendation(t *testing.T) {
 			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "We couldn’t parse your project files.", Description: "You can fix the problem and try again, or skip auto-configuration and set up your project manually. Our auto-configurator returned the following error:\nNo file found at path: ios/App/App/package.json"}),
 		},
 		{
-			name: "optionsFailed gradlew error",
-			args: args{tag: optionsFailedTag, err: `<b>No Gradle Wrapper (gradlew) found.</b>
+			name: "detectPlatformFailed gradlew error",
+			args: args{tag: detectPlatformFailedTag, err: `<b>No Gradle Wrapper (gradlew) found.</b>
 Using a Gradle Wrapper (gradlew) is required, as the wrapper is what makes sure that the right Gradle version is installed and used for the build. More info/guide: <a>https://docs.gradle.org/current/userguide/gradle_wrapper.html</a>`},
 			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{Title: "We couldn’t find your Gradle Wrapper. Please make sure there is a gradlew file in your project’s root directory.", Description: `The Gradle Wrapper ensures that the right Gradle version is installed and used for the build. You can find out more about <a target="_blank" href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">the Gradle Wrapper in the Gradle docs</a>.`}),
 		},

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -13,10 +13,8 @@ import (
 
 // Scanner ...
 type Scanner struct {
-	Projects     []Project
-	ProjectRoots []string
+	Projects []Project
 
-	ExcludeTest    bool
 	ExcludeAppIcon bool
 }
 
@@ -37,14 +35,13 @@ func (*Scanner) ExcludedScannerNames() []string {
 
 // DetectPlatform ...
 func (scanner *Scanner) DetectPlatform(searchDir string) (_ bool, err error) {
-	detected, projects, projectRoots, err := detect(searchDir)
-	scanner.ProjectRoots = projectRoots
+	detected, projects, err := detect(searchDir)
 	scanner.Projects = projects
 
 	return detected, err
 }
 
-func detect(searchDir string) (bool, []Project, []string, error) {
+func detect(searchDir string) (bool, []Project, error) {
 	projectFiles := fileGroups{
 		{"build.gradle", "build.gradle.kts"},
 		{"settings.gradle", "settings.gradle.kts"},
@@ -55,7 +52,7 @@ func detect(searchDir string) (bool, []Project, []string, error) {
 
 	projectRoots, err := walkMultipleFileGroups(searchDir, projectFiles, skipDirs)
 	if err != nil {
-		return false, []Project{}, []string{}, fmt.Errorf("failed to search for build.gradle files, error: %s", err)
+		return false, nil, fmt.Errorf("failed to search for build.gradle files, error: %s", err)
 	}
 
 	log.TSuccessf("Platform detected")
@@ -67,12 +64,12 @@ func detect(searchDir string) (bool, []Project, []string, error) {
 	log.TPrintf("%d android files detected", len(projectRoots))
 
 	if len(projectRoots) == 0 {
-		return false, []Project{}, []string{}, err
+		return false, []Project{}, err
 	}
 
 	projects, err := parseProjects(searchDir, projectRoots)
 
-	return true, projects, projectRoots, err
+	return true, projects, err
 }
 
 func parseProjects(searchDir string, projectRoots []string) ([]Project, error) {

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -115,9 +115,9 @@ func parseProjects(searchDir string, projectRoots []string) ([]Project, error) {
 		}
 
 		projects = append(projects, Project{
-			ProjectRelPath: relProjectRoot,
-			Icons:          icons,
-			Warnings:       warnings,
+			RelPath:  relProjectRoot,
+			Icons:    icons,
+			Warnings: warnings,
 		})
 	}
 
@@ -147,7 +147,7 @@ func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Ic
 		moduleOption := models.NewOption(ModuleInputTitle, ModuleInputSummary, ModuleInputEnvKey, models.TypeUserInput)
 		variantOption := models.NewOption(VariantInputTitle, VariantInputSummary, VariantInputEnvKey, models.TypeOptionalUserInput)
 
-		projectLocationOption.AddOption(project.ProjectRelPath, moduleOption)
+		projectLocationOption.AddOption(project.RelPath, moduleOption)
 		moduleOption.AddOption("app", variantOption)
 		variantOption.AddConfig("", configOption)
 	}

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -14,8 +14,6 @@ import (
 // Scanner ...
 type Scanner struct {
 	Projects []Project
-
-	ExcludeAppIcon bool
 }
 
 // NewScanner ...

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -55,21 +55,22 @@ func detect(searchDir string) (bool, []Project, error) {
 		return false, nil, fmt.Errorf("failed to search for build.gradle files, error: %s", err)
 	}
 
-	log.TSuccessf("Platform detected")
-
+	log.TPrintf("%d android files detected", len(projectRoots))
 	for _, file := range projectFiles {
 		log.TPrintf("- %s", file)
 	}
 
-	log.TPrintf("%d android files detected", len(projectRoots))
-
 	if len(projectRoots) == 0 {
-		return false, []Project{}, err
+		return false, nil, nil
 	}
+	log.TSuccessf("Platform detected")
 
 	projects, err := parseProjects(searchDir, projectRoots)
+	if err != nil {
+		return false, nil, err
+	}
 
-	return true, projects, err
+	return true, projects, nil
 }
 
 func parseProjects(searchDir string, projectRoots []string) ([]Project, error) {

--- a/scanners/android/android_test.go
+++ b/scanners/android/android_test.go
@@ -31,7 +31,7 @@ func Test_detect(t *testing.T) {
 			}},
 		}}
 
-		got, gotProj, _, err := detect(sampleAppDir)
+		got, gotProj, err := detect(sampleAppDir)
 		require.NoError(t, err)
 		require.True(t, got)
 		require.Equal(t, wantProj, gotProj)

--- a/scanners/android/android_test.go
+++ b/scanners/android/android_test.go
@@ -23,7 +23,7 @@ func Test_detect(t *testing.T) {
 		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-android-sdk22.git"
 		gitClone(t, sampleAppDir, sampleAppURL)
 
-		wantProj := []Project{{
+		want := []Project{{
 			RelPath: ".",
 			Icons: models.Icons{{
 				Filename: "81af22c35b03b30a1931a6283349eae094463aa69c52af3afe804b40dbe6dc12.png",
@@ -31,9 +31,8 @@ func Test_detect(t *testing.T) {
 			}},
 		}}
 
-		got, gotProj, err := detect(sampleAppDir)
+		got, err := detect(sampleAppDir)
 		require.NoError(t, err)
-		require.True(t, got)
-		require.Equal(t, wantProj, gotProj)
+		require.Equal(t, want, got)
 	})
 }

--- a/scanners/android/android_test.go
+++ b/scanners/android/android_test.go
@@ -23,9 +23,9 @@ func Test_detect(t *testing.T) {
 		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-android-sdk22.git"
 		gitClone(t, sampleAppDir, sampleAppURL)
 
-		wantProj := []project{{
-			projectRelPath: ".",
-			icons: models.Icons{{
+		wantProj := []Project{{
+			ProjectRelPath: ".",
+			Icons: models.Icons{{
 				Filename: "81af22c35b03b30a1931a6283349eae094463aa69c52af3afe804b40dbe6dc12.png",
 				Path:     filepath.Join(sampleAppDir, "app", "src", "main", "res", "mipmap-xxxhdpi", "ic_launcher.png"),
 			}},

--- a/scanners/android/android_test.go
+++ b/scanners/android/android_test.go
@@ -1,0 +1,39 @@
+package android
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/go-utils/command/git"
+	"github.com/stretchr/testify/require"
+)
+
+func gitClone(t *testing.T, dir, uri string) {
+	fmt.Printf("cloning into: %s\n", dir)
+	g, err := git.New(dir)
+	require.NoError(t, err)
+	require.NoError(t, g.Clone(uri).Run())
+}
+
+func Test_detect(t *testing.T) {
+	t.Run("Sample app", func(t *testing.T) {
+		sampleAppDir := t.TempDir()
+		sampleAppURL := "https://github.com/bitrise-samples/sample-apps-android-sdk22.git"
+		gitClone(t, sampleAppDir, sampleAppURL)
+
+		wantProj := []project{{
+			projectRelPath: ".",
+			icons: models.Icons{{
+				Filename: "81af22c35b03b30a1931a6283349eae094463aa69c52af3afe804b40dbe6dc12.png",
+				Path:     filepath.Join(sampleAppDir, "app", "src", "main", "res", "mipmap-xxxhdpi", "ic_launcher.png"),
+			}},
+		}}
+
+		got, gotProj, _, err := detect(sampleAppDir)
+		require.NoError(t, err)
+		require.True(t, got)
+		require.Equal(t, wantProj, gotProj)
+	})
+}

--- a/scanners/android/android_test.go
+++ b/scanners/android/android_test.go
@@ -24,7 +24,7 @@ func Test_detect(t *testing.T) {
 		gitClone(t, sampleAppDir, sampleAppURL)
 
 		wantProj := []Project{{
-			ProjectRelPath: ".",
+			RelPath: ".",
 			Icons: models.Icons{{
 				Filename: "81af22c35b03b30a1931a6283349eae094463aa69c52af3afe804b40dbe6dc12.png",
 				Path:     filepath.Join(sampleAppDir, "app", "src", "main", "res", "mipmap-xxxhdpi", "ic_launcher.png"),

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -42,6 +42,12 @@ const (
 	GradlewPathInputKey = "gradlew_path"
 )
 
+type project struct {
+	projectRelPath string
+	icons          models.Icons
+	warnings       models.Warnings
+}
+
 func walk(src string, fn func(path string, info os.FileInfo) error) error {
 	return filePathWalk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -42,10 +42,11 @@ const (
 	GradlewPathInputKey = "gradlew_path"
 )
 
-type project struct {
-	projectRelPath string
-	icons          models.Icons
-	warnings       models.Warnings
+// Project is an Android project on the filesystem
+type Project struct {
+	ProjectRelPath string
+	Icons          models.Icons
+	Warnings       models.Warnings
 }
 
 func walk(src string, fn func(path string, info os.FileInfo) error) error {

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -44,9 +44,9 @@ const (
 
 // Project is an Android project on the filesystem
 type Project struct {
-	ProjectRelPath string
-	Icons          models.Icons
-	Warnings       models.Warnings
+	RelPath  string
+	Icons    models.Icons
+	Warnings models.Warnings
 }
 
 func walk(src string, fn func(path string, info os.FileInfo) error) error {

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -53,7 +53,7 @@ func (scanner *Scanner) options() (models.OptionNode, models.Warnings, error) {
 			moduleOption := models.NewOption(android.ModuleInputTitle, android.ModuleInputSummary, android.ModuleInputEnvKey, models.TypeUserInput)
 			variantOption := models.NewOption(android.VariantInputTitle, android.VariantInputSummary, android.VariantInputEnvKey, models.TypeOptionalUserInput)
 
-			androidOptions.AddOption(project.ProjectRelPath, moduleOption)
+			androidOptions.AddOption(project.RelPath, moduleOption)
 			moduleOption.AddOption("app", variantOption)
 			variantOption.AddConfig("", configOption)
 		}

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -48,6 +48,7 @@ func (scanner *Scanner) options() (models.OptionNode, models.Warnings, error) {
 		for _, project := range scanner.androidProjects {
 			warnings = append(warnings, project.Warnings...)
 
+			// This config option is removed when merging with ios config. This way no change is needed for the working options merging.
 			configOption := models.NewConfigOption("glue-only", nil)
 			moduleOption := models.NewOption(android.ModuleInputTitle, android.ModuleInputSummary, android.ModuleInputEnvKey, models.TypeUserInput)
 			variantOption := models.NewOption(android.VariantInputTitle, android.VariantInputSummary, android.VariantInputEnvKey, models.TypeOptionalUserInput)
@@ -192,7 +193,8 @@ func (scanner *Scanner) configs(isPrivateRepo bool) (models.BitriseConfigMap, er
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, scanner.getTestSteps(relPackageJSONDir)...)
 
 	// android cd
-	if len(scanner.androidProjects) > 0 {
+	hasAndroidProject := len(scanner.androidProjects) > 0
+	if hasAndroidProject {
 		projectLocationEnv := "$" + android.ProjectLocationInputEnvKey
 
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.InstallMissingAndroidToolsStepListItem(
@@ -242,7 +244,7 @@ func (scanner *Scanner) configs(isPrivateRepo bool) (models.BitriseConfigMap, er
 				return models.BitriseConfigMap{}, err
 			}
 
-			configName := configName(len(scanner.androidProjects) > 0, true, scanner.hasTest)
+			configName := configName(hasAndroidProject, true, scanner.hasTest)
 			configMap[configName] = string(data)
 		}
 	} else {
@@ -258,7 +260,7 @@ func (scanner *Scanner) configs(isPrivateRepo bool) (models.BitriseConfigMap, er
 			return models.BitriseConfigMap{}, err
 		}
 
-		configName := configName(len(scanner.androidProjects) > 0, false, scanner.hasTest)
+		configName := configName(hasAndroidProject, false, scanner.hasTest)
 		configMap[configName] = string(data)
 	}
 

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -42,17 +42,20 @@ func (scanner *Scanner) options() (models.OptionNode, models.Warnings, error) {
 	projectDir := filepath.Dir(scanner.packageJSONPth)
 
 	// android options
-	androidOptions := models.NewOption(android.ProjectLocationInputTitle, android.ProjectLocationInputSummary, android.ProjectLocationInputEnvKey, models.TypeSelector)
-	for _, project := range scanner.androidProjects {
-		warnings = append(warnings, project.Warnings...)
+	var androidOptions *models.OptionNode
+	if len(scanner.androidProjects) > 0 {
+		androidOptions = models.NewOption(android.ProjectLocationInputTitle, android.ProjectLocationInputSummary, android.ProjectLocationInputEnvKey, models.TypeSelector)
+		for _, project := range scanner.androidProjects {
+			warnings = append(warnings, project.Warnings...)
 
-		configOption := models.NewConfigOption("glue-only", nil)
-		moduleOption := models.NewOption(android.ModuleInputTitle, android.ModuleInputSummary, android.ModuleInputEnvKey, models.TypeUserInput)
-		variantOption := models.NewOption(android.VariantInputTitle, android.VariantInputSummary, android.VariantInputEnvKey, models.TypeOptionalUserInput)
+			configOption := models.NewConfigOption("glue-only", nil)
+			moduleOption := models.NewOption(android.ModuleInputTitle, android.ModuleInputSummary, android.ModuleInputEnvKey, models.TypeUserInput)
+			variantOption := models.NewOption(android.VariantInputTitle, android.VariantInputSummary, android.VariantInputEnvKey, models.TypeOptionalUserInput)
 
-		androidOptions.AddOption(project.ProjectRelPath, moduleOption)
-		moduleOption.AddOption("app", variantOption)
-		variantOption.AddConfig("", configOption)
+			androidOptions.AddOption(project.ProjectRelPath, moduleOption)
+			moduleOption.AddOption("app", variantOption)
+			variantOption.AddConfig("", configOption)
+		}
 	}
 
 	// ios options

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -134,7 +134,7 @@ func (scanner *Scanner) options() (models.OptionNode, models.Warnings, error) {
 
 // defaultOptions implements ScannerInterface.DefaultOptions function for plain React Native projects.
 func (scanner *Scanner) defaultOptions() models.OptionNode {
-	androidOptions := (&android.Scanner{ExcludeTest: true}).DefaultOptions()
+	androidOptions := (&android.Scanner{}).DefaultOptions()
 	androidOptions.RemoveConfigs()
 
 	iosOptions := (&ios.Scanner{}).DefaultOptions()

--- a/scanners/reactnative/reactnative.go
+++ b/scanners/reactnative/reactnative.go
@@ -195,7 +195,6 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 			scanner.iosScanner.ExcludeAppIcon = true
 		}
 		androidScanner := android.NewScanner()
-		androidScanner.ExcludeAppIcon = true
 
 		projectDir := filepath.Dir(packageJSONPth)
 		isIOSProject, err := hasNativeIOSProject(searchDir, projectDir, scanner.iosScanner)

--- a/scanners/reactnative/reactnative.go
+++ b/scanners/reactnative/reactnative.go
@@ -29,9 +29,9 @@ const (
 
 // Scanner implements the project scanner for plain React Native and Expo based projects.
 type Scanner struct {
-	searchDir      string
-	iosScanner     *ios.Scanner
-	androidScanner *android.Scanner
+	searchDir       string
+	iosScanner      *ios.Scanner
+	androidProjects []android.Project
 
 	hasTest         bool
 	hasYarnLockFile bool
@@ -128,38 +128,36 @@ func parseExpoProjectSettings(packageJSONPth string) (*expoSettings, error) {
 	}, nil
 }
 
-// hasNativeProjects reports whether the project directory contains ios and android native project.
-func hasNativeProjects(searchDir, projectDir string, iosScanner *ios.Scanner, androidScanner *android.Scanner) (bool, bool, error) {
+func hasNativeIOSProject(searchDir, projectDir string, iosScanner *ios.Scanner) (bool, error) {
 	absProjectDir, err := pathutil.AbsPath(projectDir)
 	if err != nil {
-		return false, false, err
+		return false, err
 	}
 
-	iosProjectDetected := false
 	iosDir := filepath.Join(absProjectDir, "ios")
-	if exist, err := pathutil.IsDirExists(iosDir); err != nil {
-		return false, false, err
-	} else if exist {
-		if detected, err := iosScanner.DetectPlatform(searchDir); err != nil {
-			return false, false, err
-		} else if detected {
-			iosProjectDetected = true
-		}
+	if exist, err := pathutil.IsDirExists(iosDir); err != nil || !exist {
+		return false, err
 	}
 
-	androidProjectDetected := false
+	return iosScanner.DetectPlatform(searchDir)
+}
+
+func hasNativeAndroidProject(searchDir, projectDir string, androidScanner *android.Scanner) (bool, []android.Project, error) {
+	absProjectDir, err := pathutil.AbsPath(projectDir)
+	if err != nil {
+		return false, nil, err
+	}
+
 	androidDir := filepath.Join(absProjectDir, "android")
-	if exist, err := pathutil.IsDirExists(androidDir); err != nil {
-		return false, false, err
-	} else if exist {
-		if detected, err := androidScanner.DetectPlatform(searchDir); err != nil {
-			return false, false, err
-		} else if detected {
-			androidProjectDetected = true
-		}
+	if exist, err := pathutil.IsDirExists(androidDir); err != nil || !exist {
+		return false, nil, err
 	}
 
-	return iosProjectDetected, androidProjectDetected, nil
+	if detected, err := androidScanner.DetectPlatform(searchDir); err != nil || !detected {
+		return false, nil, err
+	}
+
+	return true, androidScanner.Projects, nil
 }
 
 // DetectPlatform implements ScannerInterface.DetectPlatform function.
@@ -196,22 +194,25 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 			scanner.iosScanner = ios.NewScanner()
 			scanner.iosScanner.ExcludeAppIcon = true
 		}
-		if scanner.androidScanner == nil {
-			scanner.androidScanner = android.NewScanner()
-			scanner.androidScanner.ExcludeAppIcon = true
-		}
+		androidScanner := android.NewScanner()
+		androidScanner.ExcludeAppIcon = true
 
 		projectDir := filepath.Dir(packageJSONPth)
-		ios, android, err := hasNativeProjects(searchDir, projectDir, scanner.iosScanner, scanner.androidScanner)
+		isIOSProject, err := hasNativeIOSProject(searchDir, projectDir, scanner.iosScanner)
 		if err != nil {
-			log.TWarnf("failed to check native projects: %s", err)
-		} else {
-			log.TPrintf("Found native ios project: %v", ios)
-			log.TPrintf("Found native android project: %v", android)
+			log.TWarnf("failed to check native iOS projects: %s", err)
 		}
+		log.TPrintf("Found native ios project: %v", isIOSProject)
+
+		isAndroidProject, androidProjects, err := hasNativeAndroidProject(searchDir, projectDir, androidScanner)
+		if err != nil {
+			log.TWarnf("failed to check native Android projects: %s", err)
+		}
+		log.TPrintf("Found native android project: %v", isAndroidProject)
+		scanner.androidProjects = androidProjects
 
 		if expoPrefs != nil {
-			if !(ios || android) {
+			if !(isIOSProject || isAndroidProject) {
 				expoSettings = expoPrefs
 				packageFile = packageJSONPth
 				break
@@ -219,7 +220,8 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 			log.TPrintf("Native ios/android project present, expo eject step will not be included.")
 		}
 
-		if ios || android {
+		if isIOSProject || isAndroidProject {
+			// Treating the project as a plain React Native project
 			packageFile = packageJSONPth
 			break
 		}

--- a/scanners/reactnative/reactnative.go
+++ b/scanners/reactnative/reactnative.go
@@ -203,6 +203,9 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 			log.TWarnf("failed to check native iOS projects: %s", err)
 		}
 		log.TPrintf("Found native ios project: %v", isIOSProject)
+		if !isIOSProject {
+			scanner.iosScanner = nil
+		}
 
 		isAndroidProject, androidProjects, err := hasNativeAndroidProject(searchDir, projectDir, androidScanner)
 		if err != nil {


### PR DESCRIPTION
### Context

Separated Android project parsing in a separate phase, independent of _Options()_.

This allows reuse of the code in the react-native scanner, and can be tested independently of config generation.

### Changes

* Extracted Android project parsing from Options() to parseProjects()
* react-native  options generation no longer reuses Android Options(), this allows for leaving out unused questions.