### PR TITLE
Seperated iOS Project parsing

### DIFF
--- a/scanners/ios/ios.go
+++ b/scanners/ios/ios.go
@@ -2,37 +2,6 @@ package ios
 
 import "github.com/bitrise-io/bitrise-init/models"
 
-// Scheme is an Xcode project scheme or target
-type Scheme struct {
-	Name       string
-	Missing    bool
-	HasXCTests bool
-	HasAppClip bool
-
-	Icons       models.Icons
-	IconWarning string
-}
-
-// Project is an Xcode project on the filesystem
-type Project struct {
-	// Is it a standalone project or a workspace?
-	IsWorkspace    bool
-	IsPodWorkspace bool
-
-	RelPath string
-	Schemes []Scheme
-
-	// Carthage command to run: bootstrap/update
-	CarthageCommand string
-	Warnings        models.Warnings
-}
-
-// DetectResult ...
-type DetectResult struct {
-	Projects []Project
-	Warnings models.Warnings
-}
-
 //------------------
 // ScannerInterface
 //------------------

--- a/scanners/ios/ios.go
+++ b/scanners/ios/ios.go
@@ -59,14 +59,14 @@ func (Scanner) Name() string {
 
 // DetectPlatform ...
 func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
-	if detected, err := Detect(XcodeProjectTypeIOS, searchDir); err != nil || !detected {
+	result, err := ParseProjects(XcodeProjectTypeIOS, searchDir, scanner.ExcludeAppIcon, scanner.SuppressPodFileParseError)
+	if err != nil {
 		return false, err
 	}
 
-	detectResult, err := ParseProjects(XcodeProjectTypeIOS, searchDir, scanner.ExcludeAppIcon, scanner.SuppressPodFileParseError)
-	scanner.DetectResult = detectResult
-
-	return true, err
+	scanner.DetectResult = result
+	detected := len(result.Projects) > 0
+	return detected, nil
 }
 
 // ExcludedScannerNames ...

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -2,6 +2,7 @@ package ios
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -254,11 +255,18 @@ func projectPathByScheme(projects []xcodeproj.ProjectModel, targetScheme string)
 	return ""
 }
 
+// ParseProjects collects available iOS/macOS projects
 func ParseProjects(projectType XcodeProjectType, searchDir string, excludeAppIcon, suppressPodFileParseError bool) (DetectResult, error) {
 	var (
 		projects []Project
 		warnings models.Warnings
 	)
+
+	// While not ideal, the expectation is that the searchDir is the current directory, due to using relative paths.
+	// Enforcing this to allow unit test to pass.
+	if err := os.Chdir(searchDir); err != nil {
+		return DetectResult{}, err
+	}
 
 	fileList, err := pathutil.ListPathInDirSortedByComponents(searchDir, true)
 	if err != nil {

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -577,7 +577,7 @@ func GenerateOptions(projectType XcodeProjectType, result DetectResult) (models.
 			}
 
 			for _, exportMethod := range exportMethods {
-				// Wether app-clip export Step is added later depends on the used export method
+				// Whether app-clip export Step is added later depends on the used export method
 				configDescriptor := NewConfigDescriptor(project.IsPodWorkspace, project.CarthageCommand, scheme.HasXCTests, scheme.HasAppClip, exportMethod, scheme.Missing)
 				configDescriptors = append(configDescriptors, configDescriptor)
 				configOption := models.NewConfigOption(configDescriptor.ConfigName(projectType), iconIDs)

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -106,6 +106,36 @@ const cartfileResolvedBase = "Cartfile.resolved"
 // AllowCartfileBaseFilter ...
 var AllowCartfileBaseFilter = pathutil.BaseFilter(cartfileBase, true)
 
+// Scheme is an Xcode project scheme or target
+type Scheme struct {
+	Name       string
+	Missing    bool
+	HasXCTests bool
+	HasAppClip bool
+
+	Icons models.Icons
+}
+
+// Project is an Xcode project on the filesystem
+type Project struct {
+	// Is it a standalone project or a workspace?
+	IsWorkspace    bool
+	IsPodWorkspace bool
+
+	RelPath string
+	// Carthage command to run: bootstrap/update
+	CarthageCommand string
+	Warnings        models.Warnings
+
+	Schemes []Scheme
+}
+
+// DetectResult ...
+type DetectResult struct {
+	Projects []Project
+	Warnings models.Warnings
+}
+
 // ConfigDescriptor ...
 type ConfigDescriptor struct {
 	HasPodfile           bool

--- a/scanners/ios/utility_test.go
+++ b/scanners/ios/utility_test.go
@@ -1,8 +1,10 @@
 package ios
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/command/git"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,4 +75,45 @@ func TestConfigName(t *testing.T) {
 	for _, testcase := range testCases {
 		assert.Equal(t, testcase.expectedConfigName, testcase.descriptor.ConfigName(XcodeProjectTypeIOS))
 	}
+}
+
+func gitClone(t *testing.T, dir, uri string) {
+	fmt.Printf("cloning into: %s\n", dir)
+	g, err := git.New(dir)
+	require.NoError(t, err)
+	require.NoError(t, g.Clone(uri).Run())
+}
+
+func TestParseProjects(t *testing.T) {
+	t.Run("ios-no-shared-schemes", func(t *testing.T) {
+		sampleAppDir := t.TempDir()
+		sampleAppURL := "https://github.com/bitrise-samples/ios-no-shared-schemes.git"
+		gitClone(t, sampleAppDir, sampleAppURL)
+
+		want := DetectResult{
+			Warnings: nil,
+			Projects: []Project{{
+				IsWorkspace:     false,
+				IsPodWorkspace:  false,
+				RelPath:         "BitriseXcode7Sample.xcodeproj",
+				CarthageCommand: "",
+				Warnings: []string{
+					`No shared schemes found for project: BitriseXcode7Sample.xcodeproj.
+Automatically generated schemes may differ from the ones in your project.
+Make sure to <a href="http://devcenter.bitrise.io/ios/frequent-ios-issues/#xcode-scheme-not-found">share your schemes</a> for the expected behaviour.`,
+				},
+				Schemes: []Scheme{{
+					Name:       "BitriseXcode7Sample",
+					Missing:    true,
+					HasXCTests: true,
+					HasAppClip: false,
+					Icons:      nil,
+				}},
+			}},
+		}
+
+		got, err := ParseProjects(XcodeProjectTypeIOS, sampleAppDir, false, true)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
 }

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -11,8 +11,8 @@ import (
 
 // Scanner ...
 type Scanner struct {
-	projects          []ios.Project
-	warnings          models.Warnings
+	detectResult ios.DetectResult
+
 	configDescriptors []ios.ConfigDescriptor
 }
 
@@ -28,15 +28,12 @@ func (Scanner) Name() string {
 
 // DetectPlatform ...
 func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
-	detected, err := ios.Detect(ios.XcodeProjectTypeMacOS, searchDir)
-	if err != nil {
+	if detected, err := ios.Detect(ios.XcodeProjectTypeMacOS, searchDir); err != nil || !detected {
 		return false, err
 	}
-	if !detected {
-		return false, nil
-	}
 
-	scanner.projects, scanner.warnings, err = ios.ParseProjects(ios.XcodeProjectTypeMacOS, searchDir, true, false)
+	result, err := ios.ParseProjects(ios.XcodeProjectTypeMacOS, searchDir, true, false)
+	scanner.detectResult = result
 
 	return true, err
 }
@@ -48,7 +45,7 @@ func (Scanner) ExcludedScannerNames() []string {
 
 // Options ...
 func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, error) {
-	options, configDescriptors, _, warnings, err := ios.GenerateOptions(ios.XcodeProjectTypeMacOS, scanner.projects, scanner.warnings)
+	options, configDescriptors, _, warnings, err := ios.GenerateOptions(ios.XcodeProjectTypeMacOS, scanner.detectResult)
 	if err != nil {
 		return models.OptionNode{}, warnings, nil, err
 	}

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -11,7 +11,8 @@ import (
 
 // Scanner ...
 type Scanner struct {
-	searchDir         string
+	projects          []ios.Project
+	warnings          models.Warnings
 	configDescriptors []ios.ConfigDescriptor
 }
 
@@ -27,14 +28,17 @@ func (Scanner) Name() string {
 
 // DetectPlatform ...
 func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
-	scanner.searchDir = searchDir
-
 	detected, err := ios.Detect(ios.XcodeProjectTypeMacOS, searchDir)
 	if err != nil {
 		return false, err
 	}
+	if !detected {
+		return false, nil
+	}
 
-	return detected, nil
+	scanner.projects, scanner.warnings, err = ios.ParseProjects(ios.XcodeProjectTypeMacOS, searchDir, true, false)
+
+	return true, err
 }
 
 // ExcludedScannerNames ...
@@ -44,7 +48,7 @@ func (Scanner) ExcludedScannerNames() []string {
 
 // Options ...
 func (scanner *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, error) {
-	options, configDescriptors, _, warnings, err := ios.GenerateOptions(ios.XcodeProjectTypeMacOS, scanner.searchDir, true, false)
+	options, configDescriptors, _, warnings, err := ios.GenerateOptions(ios.XcodeProjectTypeMacOS, scanner.projects, scanner.warnings)
 	if err != nil {
 		return models.OptionNode{}, warnings, nil, err
 	}

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -28,14 +28,14 @@ func (Scanner) Name() string {
 
 // DetectPlatform ...
 func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
-	if detected, err := ios.Detect(ios.XcodeProjectTypeMacOS, searchDir); err != nil || !detected {
+	result, err := ios.ParseProjects(ios.XcodeProjectTypeMacOS, searchDir, true, false)
+	if err != nil {
 		return false, err
 	}
 
-	result, err := ios.ParseProjects(ios.XcodeProjectTypeMacOS, searchDir, true, false)
 	scanner.detectResult = result
-
-	return true, err
+	detected := len(result.Projects) > 0
+	return detected, err
 }
 
 // ExcludedScannerNames ...

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -70,10 +70,10 @@ func (scanner *Scanner) options() (models.OptionNode, models.Warnings, error) {
 	if exist, err := pathutil.IsDirExists(iosDir); err != nil {
 		return models.OptionNode{}, warnings, err
 	} else if exist {
+		scanner.iosScanner.SuppressPodFileParseError = true
 		if detected, err := scanner.iosScanner.DetectPlatform(scanner.searchDir); err != nil {
 			return models.OptionNode{}, warnings, err
 		} else if detected {
-			scanner.iosScanner.SuppressPodFileParseError = true
 			options, warns, _, err := scanner.iosScanner.Options()
 			warnings = append(warnings, warns...)
 			if err != nil {


### PR DESCRIPTION
### Context

To allow reusing native iOS project scanning for react-native workflows, extracted project parsing. This includes all filesystem operations.

Resolves: https://bitrise.atlassian.net/browse/STEP-1742

### Changes
* Extract project scanning from _GenerateOptions()_ into _ParseProjects()_. This way the options are generated from an intermediary representation _DetectResult_. This allows testing the project parsing independently and reusing it in the react-native scanner.
* Remved _Detect()_, merged with _ParseProjects()_