### PR TITLE
Restore working directory

### DIFF
--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -2,7 +2,6 @@ package ios
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -294,9 +293,15 @@ func ParseProjects(projectType XcodeProjectType, searchDir string, excludeAppIco
 
 	// While not ideal, the expectation is that the searchDir is the current directory, due to using relative paths.
 	// Enforcing this to allow unit test to pass.
-	if err := os.Chdir(searchDir); err != nil {
+	undoChDir, err := pathutil.RevokableChangeDir(searchDir)
+	if err != nil {
 		return DetectResult{}, err
 	}
+	defer func() {
+		if err := undoChDir(); err != nil {
+			log.TWarnf("failed to restore working dir: %s", err)
+		}
+	}()
 
 	fileList, err := pathutil.ListPathInDirSortedByComponents(searchDir, true)
 	if err != nil {

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -291,6 +291,18 @@ func ParseProjects(projectType XcodeProjectType, searchDir string, excludeAppIco
 		warnings models.Warnings
 	)
 
+	// While not ideal, the expectation is that the searchDir is the current directory, due to using relative paths.
+	// Enforcing this to allow unit test to pass.
+	undoChDir, err := pathutil.RevokableChangeDir(searchDir)
+	if err != nil {
+		return DetectResult{}, err
+	}
+	defer func() {
+		if err := undoChDir(); err != nil {
+			log.TWarnf("failed to restore working dir: %s", err)
+		}
+	}()
+
 	fileList, err := pathutil.ListPathInDirSortedByComponents(searchDir, true)
 	if err != nil {
 		return DetectResult{}, err

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -291,18 +291,6 @@ func ParseProjects(projectType XcodeProjectType, searchDir string, excludeAppIco
 		warnings models.Warnings
 	)
 
-	// While not ideal, the expectation is that the searchDir is the current directory, due to using relative paths.
-	// Enforcing this to allow unit test to pass.
-	undoChDir, err := pathutil.RevokableChangeDir(searchDir)
-	if err != nil {
-		return DetectResult{}, err
-	}
-	defer func() {
-		if err := undoChDir(); err != nil {
-			log.TWarnf("failed to restore working dir: %s", err)
-		}
-	}()
-
 	fileList, err := pathutil.ListPathInDirSortedByComponents(searchDir, true)
 	if err != nil {
 		return DetectResult{}, err

--- a/scanners/ios/utility_test.go
+++ b/scanners/ios/utility_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/command/git"
-	"github.com/bitrise-io/go-utils/log"
-	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -113,18 +111,6 @@ Make sure to <a href="http://devcenter.bitrise.io/ios/frequent-ios-issues/#xcode
 				}},
 			}},
 		}
-
-		// While not ideal, the expectation is that the searchDir is the current directory, due to using relative paths.
-		// Enforcing this to allow unit test to pass.
-		undoChDir, err := pathutil.RevokableChangeDir(sampleAppDir)
-		if err != nil {
-			t.Fatalf("%s", err)
-		}
-		defer func() {
-			if err := undoChDir(); err != nil {
-				log.TWarnf("failed to restore working dir: %s", err)
-			}
-		}()
 
 		got, err := ParseProjects(XcodeProjectTypeIOS, sampleAppDir, false, true)
 		require.NoError(t, err)

--- a/scanners/ios/utility_test.go
+++ b/scanners/ios/utility_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/command/git"
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -111,6 +113,18 @@ Make sure to <a href="http://devcenter.bitrise.io/ios/frequent-ios-issues/#xcode
 				}},
 			}},
 		}
+
+		// While not ideal, the expectation is that the searchDir is the current directory, due to using relative paths.
+		// Enforcing this to allow unit test to pass.
+		undoChDir, err := pathutil.RevokableChangeDir(sampleAppDir)
+		if err != nil {
+			t.Fatalf("%s", err)
+		}
+		defer func() {
+			if err := undoChDir(); err != nil {
+				log.TWarnf("failed to restore working dir: %s", err)
+			}
+		}()
 
 		got, err := ParseProjects(XcodeProjectTypeIOS, sampleAppDir, false, true)
 		require.NoError(t, err)


### PR DESCRIPTION
Restore previous working directory in the iOS scanner.
This bug in addition to using a different search directory (not the root one, but for example React Native scanner looking for Android projects in the `android` directory) would have broken other (e.g. Fastlane) scanners.