### PR TITLE
Detect unsupported tools in projects

### DIFF
--- a/scanner/unknown.go
+++ b/scanner/unknown.go
@@ -14,6 +14,7 @@ import (
 
 const maxDepth = 4
 
+// UnknownToolDetector ...
 type UnknownToolDetector interface {
 	// ToolName is the human-readable name of a tool/framework/platform
 	ToolName() string
@@ -22,6 +23,7 @@ type UnknownToolDetector interface {
 	DetectToolIn(rootPath string) (DetectionResult, error)
 }
 
+// DetectionResult ...
 type DetectionResult struct {
 	Detected    bool
 	ProjectTree string

--- a/scanner/unknown.go
+++ b/scanner/unknown.go
@@ -31,6 +31,7 @@ var UnknownToolDetectors = []UnknownToolDetector{
 	toolDetector{toolName: "Tuist", primaryFile: "Project.swift"},
 	toolDetector{toolName: "Xcodegen", primaryFile: "project.yml"},
 	toolDetector{toolName: "Swift Package Manager", primaryFile: "Package.swift"},
+	toolDetector{toolName: "Bazel", primaryFile: "WORKSPACE", optionalFiles: []string{"WORKSPACE.bazel", "BUILD", "BUILD.bazel", ".bazelrc", ".bazelversion", ".bazelignore"}},
 	toolDetector{toolName: "Buck", primaryFile: "BUCK", optionalFiles: []string{".buckversion", ".buckconfig", ".buckjavaargs"}},
 	kotlinMultiplatformDetector{},
 }

--- a/scanner/unknown.go
+++ b/scanner/unknown.go
@@ -1,0 +1,209 @@
+package scanner
+
+import (
+	"io/fs"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/sliceutil"
+
+	"github.com/bitrise-io/go-utils/log"
+)
+
+const maxDepth = 3
+
+type UnknownToolDetector interface {
+	// ToolName is the human-readable name of a tool/framework/platform
+	ToolName() string
+
+	// DetectToolIn should search recursively in rootPath looking for the given tool
+	DetectToolIn(rootPath string) (DetectionResult, error)
+}
+
+type DetectionResult struct {
+	Detected    bool
+	ProjectTree string
+}
+
+var UnknownToolDetectors = []UnknownToolDetector{
+	singleFileToolDetector{toolName: "Tuist", file: "Project.swift"},
+	singleFileToolDetector{toolName: "Xcodegen", file: "project.yml"},
+	singleFileToolDetector{toolName: "Swift Package Manager", file: "Package.swift"},
+	multiFileToolDetector{toolName: "Buck", primaryFile: "BUCK", optionalFiles: []string{".buckversion", ".buckconfig", ".buckjavaargs"}},
+	kotlinMultiplatformDetector{},
+}
+
+var excludedDirs = []string{
+	".git",
+	".idea",
+	"node_modules",
+	"Pods",
+	"Carthage",
+	"CordovaLib",
+	"Framework",
+}
+
+type singleFileToolDetector struct {
+	toolName string
+	file     string
+}
+
+func (d singleFileToolDetector) ToolName() string {
+	return d.toolName
+}
+
+func (d singleFileToolDetector) DetectToolIn(rootPath string) (DetectionResult, error) {
+	fileNames, _, tree, err := walkProjectDir(rootPath)
+	if err != nil {
+		return DetectionResult{}, err
+	}
+
+	return DetectionResult{
+		Detected:    sliceutil.IsStringInSlice(d.file, fileNames),
+		ProjectTree: tree,
+	}, err
+}
+
+// multiFileToolDetector first tries to detect primaryFile in the directory, then one of optionalFiles as a fallback.
+// It detects the tool if primaryFile is found OR one of optionalFiles
+type multiFileToolDetector struct {
+	toolName      string
+	primaryFile   string
+	optionalFiles []string
+}
+
+func (d multiFileToolDetector) ToolName() string {
+	return d.toolName
+}
+
+func (d multiFileToolDetector) DetectToolIn(rootPath string) (DetectionResult, error) {
+	fileNames, _, tree, err := walkProjectDir(rootPath)
+	if err != nil {
+		return DetectionResult{}, err
+	}
+
+	if sliceutil.IsStringInSlice(d.primaryFile, fileNames) {
+		return DetectionResult{
+			Detected:    true,
+			ProjectTree: tree,
+		}, nil
+	}
+
+	optionalFileDetected := false
+	for _, fileName := range d.optionalFiles {
+		if sliceutil.IsStringInSlice(fileName, fileNames) {
+			optionalFileDetected = true
+			break
+		}
+	}
+
+	return DetectionResult{
+		Detected:    optionalFileDetected,
+		ProjectTree: tree,
+	}, nil
+
+}
+
+type kotlinMultiplatformDetector struct{}
+
+func (d kotlinMultiplatformDetector) ToolName() string {
+	return "Kotlin Multiplatform"
+}
+
+func (d kotlinMultiplatformDetector) DetectToolIn(rootPath string) (DetectionResult, error) {
+	fileNames, filePaths, tree, err := walkProjectDir(rootPath)
+	if err != nil {
+		return DetectionResult{}, err
+	}
+
+	fileNamePattern := `.+\.gradle(\.kts)?$`
+	var potentialFilePaths []string
+	for index, fileName := range fileNames {
+		match, err := regexp.MatchString(fileNamePattern, fileName)
+		if err != nil {
+			log.Warnf(err.Error())
+			continue
+		}
+		if match {
+			potentialFilePaths = append(potentialFilePaths, filePaths[index])
+		}
+	}
+
+	log.Debugf("%v", potentialFilePaths)
+
+	detected := false
+	for _, path := range potentialFilePaths {
+		bytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Warnf(err.Error())
+			continue
+		}
+
+		if d.canFindPatternIn(string(bytes)) {
+			detected = true
+			log.Debugf("%s detected in file: %s", d.ToolName(), path)
+			break
+		}
+	}
+
+	return DetectionResult{
+		Detected:    detected,
+		ProjectTree: tree,
+	}, err
+}
+
+func (d kotlinMultiplatformDetector) canFindPatternIn(fileContent string) bool {
+	return strings.Contains(fileContent, `kotlin("multiplatform")`) ||
+		strings.Contains(fileContent, `org.jetbrains.kotlin.multiplatform`)
+}
+
+// walkProjectDir recursively walks through every file and directory up to the defined depth limit while ignoring some
+// directories. It returns with a list of fileNames, a list of (absolute) filePaths and a visual tree representation
+// of the directory structure (taking the depth limit and ignored folders into account)
+func walkProjectDir(rootPath string) (fileNames []string, filePaths []string, tree string, err error) {
+	treeBuilder := strings.Builder{}
+
+	err = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			log.Warnf("error while traversing %s: %s", path, err)
+			return filepath.SkipDir
+		}
+
+		relativePath, err := filepath.Rel(rootPath, path)
+		if err != nil {
+			log.Warnf(err.Error())
+			return filepath.SkipDir
+		}
+
+		depth := strings.Count(relativePath, string(filepath.Separator)) + 1
+
+		if d.IsDir() {
+			if sliceutil.IsStringInSlice(d.Name(), excludedDirs) {
+				return filepath.SkipDir
+			}
+			if depth > maxDepth {
+				return filepath.SkipDir
+			}
+		}
+
+		fileNames = append(fileNames, d.Name())
+		filePaths = append(filePaths, path)
+
+		var treePrefix = ""
+		if depth > 1 {
+			treePrefix = strings.Repeat("· ", depth)
+		}
+		var entryName = d.Name()
+		if d.IsDir() {
+			entryName = entryName + "/"
+		}
+		treeBuilder.WriteString(treePrefix + entryName)
+		log.Debugf(treePrefix + entryName)
+
+		return nil
+	})
+
+	return fileNames, filePaths, treeBuilder.String(), err
+}

--- a/scanner/unknown.go
+++ b/scanner/unknown.go
@@ -29,7 +29,7 @@ type DetectionResult struct {
 	ProjectTree string
 }
 
-var UnknownToolDetectors = []UnknownToolDetector{
+var unknownToolDetectors = []UnknownToolDetector{
 	toolDetector{toolName: "Tuist", primaryFile: "Project.swift"},
 	toolDetector{toolName: "Xcodegen", primaryFile: "project.yml"},
 	toolDetector{toolName: "Swift Package Manager", primaryFile: "Package.swift"},

--- a/scanner/unknown.go
+++ b/scanner/unknown.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
-const maxDepth = 3
+const maxDepth = 4
 
 type UnknownToolDetector interface {
 	// ToolName is the human-readable name of a tool/framework/platform
@@ -179,8 +179,10 @@ func walkProjectDir(rootPath string) (fileNames []string, filePaths []string, tr
 		if d.IsDir() {
 			entryName = entryName + "/"
 		}
-		treeBuilder.WriteString(treePrefix + entryName + "\n")
-		log.Debugf(treePrefix + entryName)
+		if relativePath != "." {
+			treeBuilder.WriteString(treePrefix + entryName + "\n")
+			log.Debugf(treePrefix + entryName)
+		}
 
 		return nil
 	})

--- a/scanner/unknown_test.go
+++ b/scanner/unknown_test.go
@@ -1,0 +1,331 @@
+package scanner
+
+import (
+	"os"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/log"
+)
+
+func Test_kotlinMultiplatformDetector(t *testing.T) {
+	log.SetEnableDebugLog(true)
+
+	tests := []struct {
+		name     string
+		rootPath string
+		want     DetectionResult
+		wantErr  bool
+	}{
+		{
+			name:     "Empty project",
+			rootPath: t.TempDir(),
+			want:     DetectionResult{Detected: false, ProjectTree: ""},
+		},
+		{
+			name:     "Android project",
+			rootPath: createAndroidProjectFiles(t, t.TempDir()),
+			want: DetectionResult{Detected: false, ProjectTree: `app/
+· build.gradle
+build.gradle
+settings.gradle
+`},
+		},
+		{
+			name:     "Kotlin Multiplatform project",
+			rootPath: createKotlinMultiplatformFiles(t, t.TempDir()),
+			want: DetectionResult{Detected: true, ProjectTree: `app/
+· build.gradle
+build.gradle
+settings.gradle
+shared/
+· build.gradle.kts
+`},
+		},
+		{
+			name:     "Nested Kotlin Multiplatform project",
+			rootPath: createNestedKotlinMultiplatformFiles(t),
+			want: DetectionResult{Detected: true, ProjectTree: `my-project/
+· mobile/
+· · android/
+· · · app/
+· · · · build.gradle
+· · · build.gradle
+· · · settings.gradle
+· · · shared/
+· · · · build.gradle.kts
+`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := kotlinMultiplatformDetector{}
+			got, err := d.DetectToolIn(tt.rootPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DetectToolIn() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DetectToolIn() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_toolDetector(t *testing.T) {
+	log.SetEnableDebugLog(true)
+
+	tests := []struct {
+		name         string
+		toolDetector toolDetector
+		rootPath     string
+		want         DetectionResult
+		wantErr      bool
+	}{
+		{
+			name: "Primary file or optional files in empty project",
+			toolDetector: toolDetector{
+				toolName:      "Bazel",
+				primaryFile:   "WORKSPACE",
+				optionalFiles: []string{"BUILD.bazel", ".bazelrc"},
+			},
+			rootPath: t.TempDir(),
+			want:     DetectionResult{Detected: false, ProjectTree: ""},
+		},
+		{
+			name: "Primary file in Tuist project",
+			toolDetector: toolDetector{
+				toolName:      "Tuist",
+				primaryFile:   "Project.swift",
+				optionalFiles: nil,
+			},
+			rootPath: createTuistFiles(t),
+			want:     DetectionResult{Detected: true, ProjectTree: "Project.swift\n"},
+		},
+		{
+			name: "Optional files in Bazel project",
+			toolDetector: toolDetector{
+				toolName:      "Bazel",
+				primaryFile:   "WORKSPACE",
+				optionalFiles: []string{"WORKSPACE.bazel"},
+			},
+			rootPath: createBazelFiles(t),
+			want:     DetectionResult{Detected: true, ProjectTree: "WORKSPACE.bazel\n"},
+		},
+		{
+			name: "Nested project files",
+			toolDetector: toolDetector{
+				toolName:      "Kotlin Gradle script",
+				primaryFile:   "build.gradle.kts",
+				optionalFiles: nil,
+			},
+			rootPath: createNestedKotlinMultiplatformFiles(t),
+			want: DetectionResult{Detected: true, ProjectTree: `my-project/
+· mobile/
+· · android/
+· · · app/
+· · · · build.gradle
+· · · build.gradle
+· · · settings.gradle
+· · · shared/
+· · · · build.gradle.kts
+`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.toolDetector.DetectToolIn(tt.rootPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DetectToolIn() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DetectToolIn() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createAndroidProjectFiles(t *testing.T, rootPath string) string {
+	projectPath := path.Join(rootPath, "android")
+	err := os.Mkdir(projectPath, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootBuildGradle := `
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    ext.kotlin_version = "1.5.0"
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}`
+	err = os.WriteFile(path.Join(projectPath, "build.gradle"), []byte(rootBuildGradle), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	settingsGradle := `
+include ':app'
+rootProject.name = "Bitrise Sample"`
+	err = os.WriteFile(path.Join(projectPath, "settings.gradle"), []byte(settingsGradle), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Mkdir(path.Join(projectPath, "app"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	appGradle := `
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 30
+
+    defaultConfig {
+        applicationId "io.bitrise.sample.android"
+        minSdkVersion 21
+        targetSdkVersion 30
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+}`
+	err = os.WriteFile(path.Join(projectPath, "app/build.gradle"), []byte(appGradle), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return projectPath
+}
+
+func createKotlinMultiplatformFiles(t *testing.T, rootPath string) string {
+	projectPath := createAndroidProjectFiles(t, rootPath)
+
+	err := os.Mkdir(path.Join(projectPath, "shared"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sharedModuleGradle := `
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+    kotlin("plugin.serialization")
+}
+
+kotlin {
+}`
+	err = os.WriteFile(path.Join(projectPath, "shared/build.gradle.kts"), []byte(sharedModuleGradle), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return projectPath
+}
+
+func createNestedKotlinMultiplatformFiles(t *testing.T) string {
+	rootPath := path.Join(t.TempDir(), "nested")
+	projectPath := path.Join(rootPath, "my-project/mobile")
+	err := os.MkdirAll(projectPath, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createKotlinMultiplatformFiles(t, projectPath)
+
+	return rootPath
+}
+
+func createTuistFiles(t *testing.T) string {
+	projectPath := path.Join(t.TempDir(), "tuist")
+	err := os.Mkdir(projectPath, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Mkdir(path.Join(projectPath, "node_modules"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Mkdir(path.Join(projectPath, "Pods"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	projectSwift := `
+let Project = Project(name: "MyProject")
+`
+	err = os.WriteFile(path.Join(projectPath, "Project.swift"), []byte(projectSwift), 0777)
+
+	return projectPath
+}
+
+func createBazelFiles(t *testing.T) string {
+	projectPath := path.Join(t.TempDir(), "bazel")
+	err := os.Mkdir(projectPath, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Mkdir(path.Join(projectPath, "node_modules"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Mkdir(path.Join(projectPath, "Pods"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(path.Join(projectPath, "WORKSPACE.bazel"), []byte(""), 0777)
+
+	return projectPath
+}


### PR DESCRIPTION
### Context

Detect unsupported tools/frameworks/platforms in the project directory to log them later.

### Changes

- Create `scanner/unknown.go` for everything related to scanning the repo for unsupported but recognized tools. This is not a scanner though, because it needs to run only after all other platform scanners fail.
- A common interface for the various tool detectors and 3 actual implementations:
  - `singleFileToolDetector` that looks for only a single file name
  - `multiFileToolDetector` that first looks for a primary file name, but can also find one of the optional files as a fallback
  - `kotlinMultiplatformDetector` because there is no distinct file name pattern for KMM, so it also looks at the file contents of certain files 🤷 
 - While traversing the folders recursively, the detectors also build a string representation of the file tree for logging purposes. Similar to the `tree` command, but a bit simpler.

### Decisions

- Maximum scan depth is 3
- A list of excluded directories is defined in code

### Out of scope for this PR

- Wiring this into the project scanner flow
- Logging of results