### PR TITLE
Log detected tools

### DIFF
--- a/scanner/tool_detector.go
+++ b/scanner/tool_detector.go
@@ -29,7 +29,8 @@ type DetectionResult struct {
 	ProjectTree string
 }
 
-var unknownToolDetectors = []UnknownToolDetector{
+// UnknownToolDetectors ...
+var UnknownToolDetectors = []UnknownToolDetector{
 	toolDetector{toolName: "Tuist", primaryFile: "Project.swift"},
 	toolDetector{toolName: "Xcodegen", primaryFile: "project.yml"},
 	toolDetector{toolName: "Swift Package Manager", primaryFile: "Package.swift"},
@@ -113,8 +114,6 @@ func (d kotlinMultiplatformDetector) DetectToolIn(rootPath string) (DetectionRes
 		}
 	}
 
-	log.Debugf("%v", potentialFilePaths)
-
 	detected := false
 	for _, path := range potentialFilePaths {
 		bytes, err := ioutil.ReadFile(path)
@@ -125,7 +124,6 @@ func (d kotlinMultiplatformDetector) DetectToolIn(rootPath string) (DetectionRes
 
 		if d.canFindPatternIn(string(bytes)) {
 			detected = true
-			log.Debugf("%s detected in file: %s", d.ToolName(), path)
 			break
 		}
 	}
@@ -183,7 +181,6 @@ func walkProjectDir(rootPath string) (fileNames []string, filePaths []string, tr
 		}
 		if relativePath != "." {
 			treeBuilder.WriteString(treePrefix + entryName + "\n")
-			log.Debugf(treePrefix + entryName)
 		}
 
 		return nil

--- a/scanner/tool_detector_test.go
+++ b/scanner/tool_detector_test.go
@@ -5,13 +5,9 @@ import (
 	"path"
 	"reflect"
 	"testing"
-
-	"github.com/bitrise-io/go-utils/log"
 )
 
 func Test_kotlinMultiplatformDetector(t *testing.T) {
-	log.SetEnableDebugLog(true)
-
 	tests := []struct {
 		name     string
 		rootPath string
@@ -74,8 +70,6 @@ shared/
 }
 
 func Test_toolDetector(t *testing.T) {
-	log.SetEnableDebugLog(true)
-
 	tests := []struct {
 		name         string
 		toolDetector toolDetector


### PR DESCRIPTION
### Context

In #237 we added the ability to detect tools/frameworks that are not yet supported. This PR builds on that to run those tool detectors while scanning the project config and log any detected tool remotely.

### Changes

- Run the list of tool detectors in `scanner/result.go`, regardless of the scan result
- Use `analytics.LogInfo()` to log any detected tools
- Remove some debug log statements from the previous PR as I discovered that debug logs are enabled globally for the entire `bitrise-init` tool