### PR TITLE
New cache steps for Android & iOS

### DIFF
--- a/_tests/integration/android_test.go
+++ b/_tests/integration/android_test.go
@@ -147,15 +147,18 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - module: $MODULE
               - variant: $VARIANT
+              - cache_level: none
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
           - deploy-to-bitrise-io@%s: {}
@@ -176,6 +179,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
@@ -288,15 +292,18 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - module: $MODULE
               - variant: $VARIANT
+              - cache_level: none
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
           - deploy-to-bitrise-io@%s: {}
@@ -317,6 +324,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
@@ -402,15 +410,18 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - module: $MODULE
               - variant: $VARIANT
+              - cache_level: none
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
           - deploy-to-bitrise-io@%s: {}
@@ -431,6 +442,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
@@ -496,15 +508,18 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - module: $MODULE
               - variant: $VARIANT
+              - cache_level: none
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
           - deploy-to-bitrise-io@%s: {}
@@ -525,6 +540,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:

--- a/_tests/integration/android_test.go
+++ b/_tests/integration/android_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestAndroid(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"sample-apps-android-sdk22",
@@ -49,7 +47,7 @@ func TestAndroid(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 func TestMissingGradlewWrapper(t *testing.T) {
@@ -76,22 +74,20 @@ var sampleAppsAndroidSDK22SubdirVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.ChangeAndroidVersionCodeAndVersionNameVersion,
 	steps.AndroidLintVersion,
 	steps.AndroidUnitTestVersion,
 	steps.AndroidBuildVersion,
 	steps.SignAPKVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
+	steps.CacheRestoreGradleVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.AndroidUnitTestVersion,
-	steps.CachePushVersion,
+	steps.CacheSaveGradleVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -141,7 +137,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -163,7 +158,6 @@ configs:
               - variant: $VARIANT
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -174,7 +168,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-gradle-cache@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -182,7 +176,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
-          - cache-push@%s: {}
+          - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   android: []
@@ -221,22 +215,20 @@ var sampleAppsAndroid22Versions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.ChangeAndroidVersionCodeAndVersionNameVersion,
 	steps.AndroidLintVersion,
 	steps.AndroidUnitTestVersion,
 	steps.AndroidBuildVersion,
 	steps.SignAPKVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
+	steps.CacheRestoreGradleVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.AndroidUnitTestVersion,
-	steps.CachePushVersion,
+	steps.CacheSaveGradleVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -286,7 +278,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -308,7 +299,6 @@ configs:
               - variant: $VARIANT
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -319,7 +309,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-gradle-cache@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -327,7 +317,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
-          - cache-push@%s: {}
+          - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   android: []
@@ -339,22 +329,20 @@ var androidNonExecutableGradlewVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.ChangeAndroidVersionCodeAndVersionNameVersion,
 	steps.AndroidLintVersion,
 	steps.AndroidUnitTestVersion,
 	steps.AndroidBuildVersion,
 	steps.SignAPKVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
+	steps.CacheRestoreGradleVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.AndroidUnitTestVersion,
-	steps.CachePushVersion,
+	steps.CacheSaveGradleVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -404,7 +392,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -426,7 +413,6 @@ configs:
               - variant: $VARIANT
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -437,7 +423,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-gradle-cache@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -445,7 +431,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
-          - cache-push@%s: {}
+          - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   android: []
@@ -500,7 +486,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -522,7 +507,6 @@ configs:
               - variant: $VARIANT
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -533,7 +517,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-gradle-cache@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -541,7 +525,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
-          - cache-push@%s: {}
+          - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   android: []

--- a/_tests/integration/cordova_test.go
+++ b/_tests/integration/cordova_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestCordova(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"sample-apps-cordova-with-jasmine",
@@ -29,7 +27,7 @@ func TestCordova(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 // Expected results

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -128,6 +128,7 @@ configs:
               inputs:
               - lane: $FASTLANE_LANE
               - work_dir: $FASTLANE_WORK_DIR
+              - enable_cache: "no"
           - deploy-to-bitrise-io@%s: {}
   ios:
     ios-test-config: |

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -153,12 +153,14 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -174,6 +176,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
 warnings:
   fastlane: []

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestFastlane(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"fastlane",
@@ -22,7 +20,7 @@ func TestFastlane(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 // Expected results
@@ -41,17 +39,13 @@ var fastlaneVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeTestVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -153,7 +147,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -165,7 +158,6 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -176,13 +168,11 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   fastlane: []

--- a/_tests/integration/flutter_test.go
+++ b/_tests/integration/flutter_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestFlutter(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"sample-apps-flutter-ios-android",
@@ -36,7 +34,7 @@ func TestFlutter(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 // Expected results

--- a/_tests/integration/helper/execution.go
+++ b/_tests/integration/helper/execution.go
@@ -1,13 +1,14 @@
 package helper
 
 import (
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/bitrise-io/bitrise-init/output"
 	"github.com/bitrise-io/bitrise-init/scanner"
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/stretchr/testify/require"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 type TestCase struct {
@@ -18,26 +19,29 @@ type TestCase struct {
 	ExpectedVersions []interface{}
 }
 
-func Execute(t *testing.T, tmpDir string, testCases []TestCase) {
+func Execute(t *testing.T, testCases []TestCase) {
 	for _, testCase := range testCases {
-		t.Log("Executing :", testCase.Name)
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Log("Executing :", testCase.Name)
 
-		sampleAppDir := filepath.Join(tmpDir, testCase.Name)
+			sampleAppDir := filepath.Join(t.TempDir(), testCase.Name)
 
-		if testCase.Branch != "" {
-			GitCloneBranch(t, sampleAppDir, testCase.RepoURL, testCase.Branch)
-		} else {
-			GitClone(t, sampleAppDir, testCase.RepoURL)
-		}
+			if testCase.Branch != "" {
+				GitCloneBranch(t, sampleAppDir, testCase.RepoURL, testCase.Branch)
+			} else {
+				GitClone(t, sampleAppDir, testCase.RepoURL)
+			}
 
-		_, err := scanner.GenerateAndWriteResults(sampleAppDir, sampleAppDir, output.YAMLFormat)
-		require.NoError(t, err)
+			_, err := scanner.GenerateAndWriteResults(sampleAppDir, sampleAppDir, output.YAMLFormat)
+			require.NoError(t, err)
 
-		scanResultPth := filepath.Join(sampleAppDir, "result.yml")
+			scanResultPth := filepath.Join(sampleAppDir, "result.yml")
 
-		result, err := fileutil.ReadStringFromFile(scanResultPth)
-		require.NoError(t, err)
+			result, err := fileutil.ReadStringFromFile(scanResultPth)
+			require.NoError(t, err)
 
-		ValidateConfigExpectation(t, testCase.Name, strings.TrimSpace(testCase.ExpectedResult), strings.TrimSpace(result), testCase.ExpectedVersions)
+			ValidateConfigExpectation(t, testCase.Name, strings.TrimSpace(testCase.ExpectedResult), strings.TrimSpace(result), testCase.ExpectedVersions)
+		})
+
 	}
 }

--- a/_tests/integration/ionic_test.go
+++ b/_tests/integration/ionic_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestIonic(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"ionic-2",
@@ -22,7 +20,7 @@ func TestIonic(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 // Expected results

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -130,12 +130,14 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -154,6 +156,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
@@ -251,12 +254,14 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -274,6 +279,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - save-cocoapods-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
@@ -435,6 +441,7 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -450,6 +457,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
     ios-test-config: |
       format_version: "%s"
@@ -473,12 +481,14 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -494,6 +504,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
@@ -581,12 +592,14 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -606,6 +619,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - save-carthage-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
@@ -730,6 +744,7 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - export-xcarchive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -752,6 +767,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
     ios-app-clip-app-store-config: |
       format_version: "%s"
@@ -776,6 +792,7 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -791,6 +808,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
     ios-app-clip-development-config: |
       format_version: "%s"
@@ -815,6 +833,7 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - export-xcarchive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -837,6 +856,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
     ios-app-clip-enterprise-config: |
       format_version: "%s"
@@ -861,6 +881,7 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -876,6 +897,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestIOS(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"ios-no-shared-schemes",
@@ -50,7 +48,7 @@ func TestIOS(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 // Expected results
@@ -59,19 +57,14 @@ var iosNoSharedSchemesVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
-
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.XcodeTestVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -129,7 +122,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -144,7 +136,6 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -155,7 +146,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -164,7 +154,6 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
@@ -188,19 +177,17 @@ var iosCocoapodsAtRootVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
+	steps.CacheRestoreCocoapodsVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestVersion,
-	steps.CachePushVersion,
+	steps.CacheSaveCocoapodsVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -258,7 +245,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
@@ -271,7 +257,6 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -282,14 +267,14 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-cocoapods-cache@%s: {}
           - cocoapods-install@%s: {}
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
-          - cache-push@%s: {}
+          - save-cocoapods-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
@@ -301,32 +286,24 @@ var sampleAppsIosWatchkitVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeBuildForTestVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeTestVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -452,14 +429,12 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -470,13 +445,11 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
     ios-test-config: |
       format_version: "%s"
@@ -495,7 +468,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -507,7 +479,6 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -518,13 +489,11 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
@@ -536,19 +505,17 @@ var sampleAppsCarthageVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.CarthageVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
+	steps.CacheRestoreCarthageVersion,
 	steps.CarthageVersion,
 	steps.XcodeTestVersion,
-	steps.CachePushVersion,
+	steps.CacheSaveCarthageVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -606,7 +573,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - carthage@%s:
               inputs:
               - carthage_command: bootstrap
@@ -621,7 +587,6 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -632,7 +597,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-carthage-cache@%s: {}
           - carthage@%s:
               inputs:
               - carthage_command: bootstrap
@@ -641,7 +606,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
-          - cache-push@%s: {}
+          - save-carthage-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
@@ -654,70 +619,54 @@ var sampleAppClipVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeArchiveVersion,
 	steps.ExportXCArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// ios-app-clip-ad-hoc-config/primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeBuildForTestVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// ios-app-clip-app-store-config/deploy
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// ios-app-clip-app-store-config/primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeBuildForTestVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// ios-app-clip-development-config/deploy
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeArchiveVersion,
 	steps.ExportXCArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// ios-app-clip-development-config/primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeBuildForTestVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// ios-app-clip-enterprise-config/deploy
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// ios-app-clip-enterprise-config/primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeBuildForTestVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -775,7 +724,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -789,7 +737,6 @@ configs:
               - product: app-clip
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -800,13 +747,11 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
     ios-app-clip-app-store-config: |
       format_version: "%s"
@@ -825,14 +770,12 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -843,13 +786,11 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
     ios-app-clip-development-config: |
       format_version: "%s"
@@ -868,7 +809,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -882,7 +822,6 @@ configs:
               - product: app-clip
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -893,13 +832,11 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
     ios-app-clip-enterprise-config: |
       format_version: "%s"
@@ -918,14 +855,12 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -936,13 +871,11 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-build-for-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -248,7 +248,9 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cocoapods-install@%s: {}
+          - cocoapods-install@%s:
+              inputs:
+              - is_cache_disabled: "true"
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -273,7 +275,9 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - restore-cocoapods-cache@%s: {}
-          - cocoapods-install@%s: {}
+          - cocoapods-install@%s:
+              inputs:
+              - is_cache_disabled: "true"
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH

--- a/_tests/integration/mac_test.go
+++ b/_tests/integration/mac_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestMacOS(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"sample-apps-osx-10-11",
@@ -22,7 +20,7 @@ func TestMacOS(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 // Expected results
@@ -31,18 +29,14 @@ var sampleAppsOSX1011Versions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.XcodeTestMacVersion,
 	steps.XcodeArchiveMacVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.XcodeTestMacVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -94,7 +88,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - certificate-and-profile-installer@%s: {}
           - xcode-test-mac@%s:
               inputs:
@@ -105,18 +98,15 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - export_method: $BITRISE_EXPORT_METHOD
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - xcode-test-mac@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   macos: []

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1041,7 +1041,9 @@ configs:
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
-          - cocoapods-install@%s: {}
+          - cocoapods-install@%s:
+              inputs:
+              - is_cache_disabled: "true"
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -1069,7 +1071,9 @@ configs:
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
-          - cocoapods-install@%s: {}
+          - cocoapods-install@%s:
+              inputs:
+              - is_cache_disabled: "true"
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -1092,7 +1096,9 @@ configs:
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
-          - cocoapods-install@%s: {}
+          - cocoapods-install@%s:
+              inputs:
+              - is_cache_disabled: "true"
           - xcode-test-mac@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -1111,7 +1117,9 @@ configs:
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
-          - cocoapods-install@%s: {}
+          - cocoapods-install@%s:
+              inputs:
+              - is_cache_disabled: "true"
           - xcode-test-mac@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -42,22 +42,20 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.ChangeAndroidVersionCodeAndVersionNameVersion,
 	steps.AndroidLintVersion,
 	steps.AndroidUnitTestVersion,
 	steps.AndroidBuildVersion,
 	steps.SignAPKVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
+	steps.CacheRestoreGradleVersion,
 	steps.InstallMissingAndroidToolsVersion,
 	steps.AndroidUnitTestVersion,
-	steps.CachePushVersion,
+	steps.CacheSaveGradleVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// cordova
@@ -221,43 +219,39 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestVersion,
 	steps.XcodeArchiveVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
+	steps.CacheRestoreCocoapodsVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestVersion,
-	steps.CachePushVersion,
+	steps.CacheSaveCocoapodsVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// macos
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestMacVersion,
 	steps.XcodeArchiveMacVersion,
-	steps.CachePushVersion,
 	steps.DeployToBitriseIoVersion,
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CachePullVersion,
+	steps.CacheRestoreCocoapodsVersion,
 	steps.RecreateUserSchemesVersion,
 	steps.CocoapodsInstallVersion,
 	steps.XcodeTestMacVersion,
-	steps.CachePushVersion,
+	steps.CacheSaveCocoapodsVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// other
@@ -590,7 +584,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -612,7 +605,6 @@ configs:
               - variant: $VARIANT
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -623,7 +615,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-gradle-cache@%s: {}
           - install-missing-android-tools@%s:
               inputs:
               - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -631,7 +623,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
-          - cache-push@%s: {}
+          - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
   cordova:
     default-cordova-config: |
@@ -1040,7 +1032,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -1056,7 +1047,6 @@ configs:
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -1067,7 +1057,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-cocoapods-cache@%s: {}
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -1077,7 +1067,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
-          - cache-push@%s: {}
+          - save-cocoapods-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
   macos:
     default-macos-config: |
@@ -1089,7 +1079,6 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
           - certificate-and-profile-installer@%s: {}
           - recreate-user-schemes@%s:
               inputs:
@@ -1104,13 +1093,12 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - export_method: $BITRISE_EXPORT_METHOD
-          - cache-push@%s: {}
           - deploy-to-bitrise-io@%s: {}
         primary:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - cache-pull@%s: {}
+          - restore-cocoapods-cache@%s: {}
           - recreate-user-schemes@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
@@ -1119,7 +1107,7 @@ configs:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
-          - cache-push@%s: {}
+          - save-cocoapods-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
   other:
     other-config: |

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -594,15 +594,18 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-unit-test@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - android-build@%s:
               inputs:
               - project_location: $PROJECT_LOCATION
               - module: $MODULE
               - variant: $VARIANT
+              - cache_level: none
           - sign-apk@%s:
               run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
           - deploy-to-bitrise-io@%s: {}
@@ -623,6 +626,7 @@ configs:
               inputs:
               - project_location: $PROJECT_LOCATION
               - variant: $VARIANT
+              - cache_level: none
           - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
   cordova:
@@ -670,6 +674,7 @@ configs:
               inputs:
               - lane: $FASTLANE_LANE
               - work_dir: $FASTLANE_WORK_DIR
+              - enable_cache: "no"
           - deploy-to-bitrise-io@%s: {}
     default-fastlane-ios-config: |
       format_version: "%s"
@@ -691,6 +696,7 @@ configs:
               inputs:
               - lane: $FASTLANE_LANE
               - work_dir: $FASTLANE_WORK_DIR
+              - enable_cache: "no"
           - deploy-to-bitrise-io@%s: {}
   flutter:
     flutter-config-notest-app-android: |
@@ -1041,12 +1047,14 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - automatic_code_signing: api-key
+              - cache_level: none
           - deploy-to-bitrise-io@%s: {}
         primary:
           description: |
@@ -1067,6 +1075,7 @@ configs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
+              - cache_level: none
           - save-cocoapods-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
   macos:

--- a/_tests/integration/reactnative_expo_test.go
+++ b/_tests/integration/reactnative_expo_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestReactNativeExpo(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"managed-workflow-no-tests",
@@ -36,7 +34,7 @@ func TestReactNativeExpo(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 // Expected results

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -937,7 +937,9 @@ configs:
               - project_location: $PROJECT_LOCATION
               - module: $MODULE
               - variant: $VARIANT
-          - cocoapods-install@%s: {}
+          - cocoapods-install@%s:
+              inputs:
+              - is_cache_disabled: "true"
           - xcode-archive@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -42,8 +42,6 @@ const noTestPackageJSON = `{
 const simpleSample = "https://github.com/bitrise-samples/sample-apps-react-native-ios-and-android.git"
 
 func TestReactNative(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	var testCases = []helper.TestCase{
 		{
 			"joplin",
@@ -68,7 +66,7 @@ func TestReactNative(t *testing.T) {
 		},
 	}
 
-	helper.Execute(t, tmpDir, testCases)
+	helper.Execute(t, testCases)
 }
 
 func TestNoTests(t *testing.T) {

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -40,6 +40,9 @@ const (
 	ModuleInputSummary = "Modules provide a container for your Android project's source code, resource files, and app level settings, such as the module-level build file and Android manifest file. Each module can be independently built, tested, and debugged. You can add new modules to your Bitrise builds at any time."
 
 	GradlewPathInputKey = "gradlew_path"
+
+	CacheLevelInputKey = "cache_level"
+	CacheLevelNone     = "none"
 )
 
 // Project is an Android project on the filesystem
@@ -159,6 +162,9 @@ func (scanner *Scanner) generateConfigBuilder(isPrivateRepository bool) models.C
 		envmanModels.EnvironmentItemModel{
 			VariantInputKey: variantEnv,
 		},
+		envmanModels.EnvironmentItemModel{
+			CacheLevelInputKey: CacheLevelNone,
+		},
 	))
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveGradleCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(false)...)
@@ -184,6 +190,9 @@ func (scanner *Scanner) generateConfigBuilder(isPrivateRepository bool) models.C
 		envmanModels.EnvironmentItemModel{
 			VariantInputKey: variantEnv,
 		},
+		envmanModels.EnvironmentItemModel{
+			CacheLevelInputKey: CacheLevelNone,
+		},
 	))
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.AndroidUnitTestStepListItem(
 		envmanModels.EnvironmentItemModel{
@@ -191,6 +200,9 @@ func (scanner *Scanner) generateConfigBuilder(isPrivateRepository bool) models.C
 		},
 		envmanModels.EnvironmentItemModel{
 			VariantInputKey: variantEnv,
+		},
+		envmanModels.EnvironmentItemModel{
+			CacheLevelInputKey: CacheLevelNone,
 		},
 	))
 
@@ -203,6 +215,9 @@ func (scanner *Scanner) generateConfigBuilder(isPrivateRepository bool) models.C
 		},
 		envmanModels.EnvironmentItemModel{
 			VariantInputKey: variantEnv,
+		},
+		envmanModels.EnvironmentItemModel{
+			CacheLevelInputKey: CacheLevelNone,
 		},
 	))
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.SignAPKStepListItem())

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -145,9 +145,10 @@ func (scanner *Scanner) generateConfigBuilder(isPrivateRepository bool) models.C
 
 	//-- primary
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-		ShouldIncludeCache:       true,
+		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: isPrivateRepository,
 	})...)
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreGradleCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.InstallMissingAndroidToolsStepListItem(
 		envmanModels.EnvironmentItemModel{GradlewPathInputKey: gradlewPath},
 	))
@@ -159,12 +160,13 @@ func (scanner *Scanner) generateConfigBuilder(isPrivateRepository bool) models.C
 			VariantInputKey: variantEnv,
 		},
 	))
-	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(true)...)
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveGradleCache())
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(false)...)
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryWorkflowDescription)
 
 	//-- deploy
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-		ShouldIncludeCache:       true,
+		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: isPrivateRepository,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.InstallMissingAndroidToolsStepListItem(
@@ -204,7 +206,7 @@ func (scanner *Scanner) generateConfigBuilder(isPrivateRepository bool) models.C
 		},
 	))
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.SignAPKStepListItem())
-	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepListV2(true)...)
+	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultDeployStepListV2(false)...)
 
 	configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployWorkflowDescription)
 

--- a/scanners/fastlane/fastlane.go
+++ b/scanners/fastlane/fastlane.go
@@ -54,6 +54,11 @@ const (
 	fastlaneXcodeListTimeoutEnvValue = "120"
 )
 
+const (
+	cacheInputKey = "enable_cache"
+	cacheInputNo  = "no"
+)
+
 //------------------
 // ScannerInterface
 //------------------
@@ -198,6 +203,7 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.FastlaneStepListItem(
 			envmanModels.EnvironmentItemModel{laneInputKey: "$" + laneInputEnvKey},
 			envmanModels.EnvironmentItemModel{workDirInputKey: "$" + workDirInputEnvKey},
+			envmanModels.EnvironmentItemModel{cacheInputKey: cacheInputNo},
 		))
 
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
@@ -249,6 +255,7 @@ func (*Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.FastlaneStepListItem(
 			envmanModels.EnvironmentItemModel{laneInputKey: "$" + laneInputEnvKey},
 			envmanModels.EnvironmentItemModel{workDirInputKey: "$" + workDirInputEnvKey},
+			envmanModels.EnvironmentItemModel{cacheInputKey: cacheInputNo},
 		))
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
 

--- a/scanners/flutter/flutter.go
+++ b/scanners/flutter/flutter.go
@@ -317,7 +317,7 @@ func (scanner Scanner) generateConfigMap(isPrivateRepository bool) (models.Bitri
 
 		// Common steps to all workflows
 		prepareSteps := steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-			ShouldIncludeCache:       false,
+			ShouldIncludeLegacyCache: false,
 			ShouldIncludeActivateSSH: isPrivateRepository,
 		})
 		flutterInstallStep := steps.FlutterInstallStepListItem(

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -575,8 +575,7 @@ func GenerateConfigBuilder(
 	hasPodfile,
 	hasTest,
 	hasAppClip,
-	missingSharedSchemes,
-	includeCache bool,
+	missingSharedSchemes bool,
 	carthageCommand,
 	exportMethod string,
 ) models.ConfigBuilderModel {
@@ -586,7 +585,6 @@ func GenerateConfigBuilder(
 		projectType:          projectType,
 		configBuilder:        configBuilder,
 		isPrivateRepository:  isPrivateRepository,
-		includeCache:         includeCache,
 		missingSharedSchemes: missingSharedSchemes,
 		hasTests:             hasTest,
 		hasAppClip:           hasAppClip,
@@ -628,7 +626,6 @@ func GenerateConfig(projectType XcodeProjectType, configDescriptors []ConfigDesc
 			descriptor.HasTest,
 			descriptor.HasAppClip,
 			descriptor.MissingSharedSchemes,
-			true,
 			descriptor.CarthageCommand,
 			descriptor.ExportMethod)
 
@@ -656,7 +653,6 @@ func GenerateDefaultConfig(projectType XcodeProjectType) (models.BitriseConfigMa
 		true,
 		true,
 		false,
-		true,
 		true,
 		"",
 		"")

--- a/scanners/ios/workflow.go
+++ b/scanners/ios/workflow.go
@@ -7,18 +7,14 @@ import (
 )
 
 const (
-	// TestRepetitionModeKey ...
-	TestRepetitionModeKey = "test_repetition_mode"
-	// TestRepetitionModeRetryOnFailureValue ...
+	TestRepetitionModeKey                 = "test_repetition_mode"
 	TestRepetitionModeRetryOnFailureValue = "retry_on_failure"
-	// BuildForTestDestinationKey ...
-	BuildForTestDestinationKey = "destination"
-	// BuildForTestDestinationValue ...
-	BuildForTestDestinationValue = "platform=iOS Simulator,name=iPhone 8 Plus,OS=latest"
-	// AutomaticCodeSigningKey ...
-	AutomaticCodeSigningKey = "automatic_code_signing"
-	// AutomaticCodeSigningValue ...
-	AutomaticCodeSigningValue = "api-key"
+	BuildForTestDestinationKey            = "destination"
+	BuildForTestDestinationValue          = "platform=iOS Simulator,name=iPhone 8 Plus,OS=latest"
+	AutomaticCodeSigningKey               = "automatic_code_signing"
+	AutomaticCodeSigningValue             = "api-key"
+	CacheLevelKey                         = "cache_level"
+	CacheLevelNone                        = "none"
 )
 
 const primaryTestDescription = `The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.`
@@ -185,6 +181,7 @@ func baseXcodeStepInputModels() []envmanModels.EnvironmentItemModel {
 func xcodeTestStepInputModels() []envmanModels.EnvironmentItemModel {
 	inputModels := []envmanModels.EnvironmentItemModel{
 		{TestRepetitionModeKey: TestRepetitionModeRetryOnFailureValue},
+		{CacheLevelKey: CacheLevelNone},
 	}
 
 	return append(baseXcodeStepInputModels(), inputModels...)
@@ -193,6 +190,7 @@ func xcodeTestStepInputModels() []envmanModels.EnvironmentItemModel {
 func xcodeBuildForTestStepInputModels() []envmanModels.EnvironmentItemModel {
 	inputModels := []envmanModels.EnvironmentItemModel{
 		{BuildForTestDestinationKey: BuildForTestDestinationValue},
+		{CacheLevelKey: CacheLevelNone},
 	}
 
 	return append(baseXcodeStepInputModels(), inputModels...)
@@ -205,6 +203,7 @@ func xcodeArchiveStepInputModels(projectType XcodeProjectType) []envmanModels.En
 		inputModels = append(inputModels, []envmanModels.EnvironmentItemModel{
 			{DistributionMethodInputKey: "$" + DistributionMethodEnvKey},
 			{AutomaticCodeSigningKey: AutomaticCodeSigningValue},
+			{CacheLevelKey: CacheLevelNone},
 		}...)
 	} else {
 		inputModels = []envmanModels.EnvironmentItemModel{

--- a/scanners/reactnative/expo.go
+++ b/scanners/reactnative/expo.go
@@ -52,7 +52,7 @@ func (scanner *Scanner) expoConfigs(project project, isPrivateRepo bool) (models
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryDescription)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-		ShouldIncludeCache:       false,
+		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: isPrivateRepo,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, testSteps...)
@@ -67,7 +67,7 @@ func (scanner *Scanner) expoConfigs(project project, isPrivateRepo bool) (models
 
 	configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployDescription)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-		ShouldIncludeCache:       false,
+		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: isPrivateRepo,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, testSteps...)
@@ -112,7 +112,7 @@ func (scanner Scanner) expoDefaultConfigs() (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, expoPrimaryWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-		ShouldIncludeCache:       false,
+		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: true,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, getTestSteps("$"+expoProjectDirInputEnvKey, true, true)...)
@@ -121,7 +121,7 @@ func (scanner Scanner) expoDefaultConfigs() (models.BitriseConfigMap, error) {
 	// deploy workflow
 	configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, expoDeployWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-		ShouldIncludeCache:       false,
+		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: true,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, getTestSteps("$"+expoProjectDirInputEnvKey, true, true)...)

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -187,7 +187,7 @@ func (scanner *Scanner) configs(isPrivateRepo bool) (models.BitriseConfigMap, er
 
 		configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryDescription)
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-			ShouldIncludeCache:       false,
+			ShouldIncludeLegacyCache: false,
 			ShouldIncludeActivateSSH: isPrivateRepo,
 		})...)
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, testSteps...)
@@ -197,7 +197,7 @@ func (scanner *Scanner) configs(isPrivateRepo bool) (models.BitriseConfigMap, er
 		// cd
 		configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployWorkflowDescription)
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-			ShouldIncludeCache:       false,
+			ShouldIncludeLegacyCache: false,
 			ShouldIncludeActivateSSH: isPrivateRepo,
 		})...)
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, testSteps...)
@@ -268,7 +268,7 @@ func (scanner *Scanner) defaultConfigs() (models.BitriseConfigMap, error) {
 	// primary
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-		ShouldIncludeCache:       false,
+		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: true,
 	})...)
 	// Assuming project uses yarn and has tests
@@ -278,7 +278,7 @@ func (scanner *Scanner) defaultConfigs() (models.BitriseConfigMap, error) {
 	// deploy
 	configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepListV2(steps.PrepareListParams{
-		ShouldIncludeCache:       false,
+		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: true,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, getTestSteps("", true, true)...)

--- a/steps/cachesteps.go
+++ b/steps/cachesteps.go
@@ -1,0 +1,33 @@
+package steps
+
+import bitriseModels "github.com/bitrise-io/bitrise/models"
+
+func RestoreGradleCache() bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(CacheRestoreGradleID, CacheRestoreGradleVersion)
+	return stepListItem(stepIDComposite, "", "")
+}
+
+func SaveGradleCache() bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(CacheSaveGradleID, CacheSaveGradleVersion)
+	return stepListItem(stepIDComposite, "", "")
+}
+
+func RestoreCocoapodsCache() bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(CacheRestoreCocoapodsID, CacheRestoreCocoapodsVersion)
+	return stepListItem(stepIDComposite, "", "")
+}
+
+func SaveCocoapodsCache() bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(CacheSaveCocoapodsID, CacheSaveCocoapodsVersion)
+	return stepListItem(stepIDComposite, "", "")
+}
+
+func RestoreCarthageCache() bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(CacheRestoreCarthageID, CacheRestoreCarthageVersion)
+	return stepListItem(stepIDComposite, "", "")
+}
+
+func SaveCarthageCache() bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(CacheSaveCarthageID, CacheSaveCarthageVersion)
+	return stepListItem(stepIDComposite, "", "")
+}

--- a/steps/const.go
+++ b/steps/const.go
@@ -1,251 +1,195 @@
 package steps
 
 const (
-	// ActivateSSHKeyID ...
-	ActivateSSHKeyID = "activate-ssh-key"
-	// ActivateSSHKeyVersion ...
+	ActivateSSHKeyID      = "activate-ssh-key"
 	ActivateSSHKeyVersion = "4"
 )
 
 const (
-	// AndroidLintID ...
-	AndroidLintID = "android-lint"
-	// AndroidLintVersion ...
+	AndroidLintID      = "android-lint"
 	AndroidLintVersion = "0"
 )
 
 const (
-	// AndroidUnitTestID ...
-	AndroidUnitTestID = "android-unit-test"
-	// AndroidUnitTestVersion ...
+	AndroidUnitTestID      = "android-unit-test"
 	AndroidUnitTestVersion = "1"
 )
 
 const (
-	// AndroidBuildID ...
-	AndroidBuildID = "android-build"
-	// AndroidBuildVersion ...
+	AndroidBuildID      = "android-build"
 	AndroidBuildVersion = "1"
 )
 
 const (
-	// GitCloneID ...
-	GitCloneID = "git-clone"
-	// GitCloneVersion ...
+	GitCloneID      = "git-clone"
 	GitCloneVersion = "7"
 )
 
 const (
-	// CachePullID ...
-	CachePullID = "cache-pull"
-	// CachePullVersion ...
+	CachePullID      = "cache-pull"
 	CachePullVersion = "2"
 )
 
 const (
-	// CachePushID ...
-	CachePushID = "cache-push"
-	// CachePushVersion ...
+	CachePushID      = "cache-push"
 	CachePushVersion = "2"
 )
 
 const (
-	// CertificateAndProfileInstallerID ...
-	CertificateAndProfileInstallerID = "certificate-and-profile-installer"
-	// CertificateAndProfileInstallerVersion ...
+	CacheRestoreGradleID         = "restore-gradle-cache"
+	CacheRestoreGradleVersion    = "1"
+	CacheRestoreCocoapodsID      = "restore-cocoapods-cache"
+	CacheRestoreCocoapodsVersion = "1"
+	CacheRestoreCarthageID       = "restore-carthage-cache"
+	CacheRestoreCarthageVersion  = "1"
+
+	CacheSaveGradleID         = "save-gradle-cache"
+	CacheSaveGradleVersion    = "1"
+	CacheSaveCocoapodsID      = "save-cocoapods-cache"
+	CacheSaveCocoapodsVersion = "1"
+	CacheSaveCarthageID       = "save-carthage-cache"
+	CacheSaveCarthageVersion  = "1"
+)
+
+const (
+	CertificateAndProfileInstallerID      = "certificate-and-profile-installer"
 	CertificateAndProfileInstallerVersion = "1"
 )
 
 const (
-	// ChangeAndroidVersionCodeAndVersionNameID ...
-	ChangeAndroidVersionCodeAndVersionNameID = "change-android-versioncode-and-versionname"
-	// ChangeAndroidVersionCodeAndVersionNameVersion ...
+	ChangeAndroidVersionCodeAndVersionNameID      = "change-android-versioncode-and-versionname"
 	ChangeAndroidVersionCodeAndVersionNameVersion = "1"
 )
 
 const (
-	// DeployToBitriseIoID ...
-	DeployToBitriseIoID = "deploy-to-bitrise-io"
-	// DeployToBitriseIoVersion ...
+	DeployToBitriseIoID      = "deploy-to-bitrise-io"
 	DeployToBitriseIoVersion = "2"
 )
 
 const (
-	// ScriptID ...
-	ScriptID = "script"
-	// ScriptVersion ...
-	ScriptVersion = "1"
-	// ScriptDefaultTitle ...
+	ScriptID           = "script"
+	ScriptVersion      = "1"
 	ScriptDefaultTitle = "Do anything with Script step"
 )
 
 const (
-	// SignAPKID ...
-	SignAPKID = "sign-apk"
-	// SignAPKVersion ...
+	SignAPKID      = "sign-apk"
 	SignAPKVersion = "1"
 )
 
 const (
-	// InstallMissingAndroidToolsID ...
-	InstallMissingAndroidToolsID = "install-missing-android-tools"
-	// InstallMissingAndroidToolsVersion ...
+	InstallMissingAndroidToolsID      = "install-missing-android-tools"
 	InstallMissingAndroidToolsVersion = "3"
 )
 
 const (
-	// FastlaneID ...
-	FastlaneID = "fastlane"
-	// FastlaneVersion ...
+	FastlaneID      = "fastlane"
 	FastlaneVersion = "3"
 )
 
 const (
-	// CocoapodsInstallID ...
-	CocoapodsInstallID = "cocoapods-install"
-	// CocoapodsInstallVersion ...
+	CocoapodsInstallID      = "cocoapods-install"
 	CocoapodsInstallVersion = "2"
 )
 
 const (
-	// CarthageID ...
-	CarthageID = "carthage"
-	// CarthageVersion ...
+	CarthageID      = "carthage"
 	CarthageVersion = "3"
 )
 
 const (
-	// RecreateUserSchemesID ...
-	RecreateUserSchemesID = "recreate-user-schemes"
-	// RecreateUserSchemesVersion ...
+	RecreateUserSchemesID      = "recreate-user-schemes"
 	RecreateUserSchemesVersion = "1"
 )
 
 const (
-	// XcodeArchiveID ...
-	XcodeArchiveID = "xcode-archive"
-	// XcodeArchiveVersion ...
+	XcodeArchiveID      = "xcode-archive"
 	XcodeArchiveVersion = "4"
 )
 
 const (
-	// XcodeTestID ...
-	XcodeTestID = "xcode-test"
-	// XcodeTestVersion ...
+	XcodeTestID      = "xcode-test"
 	XcodeTestVersion = "4"
 )
 
 const (
-	// XcodeBuildForTestID ...
-	XcodeBuildForTestID = "xcode-build-for-test"
-	// XcodeBuildForTestVersion ...
+	XcodeBuildForTestID      = "xcode-build-for-test"
 	XcodeBuildForTestVersion = "1"
 )
 
 const (
-	// XcodeArchiveMacID ...
-	XcodeArchiveMacID = "xcode-archive-mac"
-	// XcodeArchiveMacVersion ...
+	XcodeArchiveMacID      = "xcode-archive-mac"
 	XcodeArchiveMacVersion = "1"
 )
 
 const (
-	// ExportXCArchiveID ...
-	ExportXCArchiveID = "export-xcarchive"
-	// ExportXCArchiveVersion ...
+	ExportXCArchiveID      = "export-xcarchive"
 	ExportXCArchiveVersion = "4"
 )
 
 const (
-	// XcodeTestMacID ...
-	XcodeTestMacID = "xcode-test-mac"
-	// XcodeTestMacVersion ...
+	XcodeTestMacID      = "xcode-test-mac"
 	XcodeTestMacVersion = "1"
 )
 
 const (
-	// CordovaArchiveID ...
-	CordovaArchiveID = "cordova-archive"
-	// CordovaArchiveVersion ...
+	CordovaArchiveID      = "cordova-archive"
 	CordovaArchiveVersion = "3"
 )
 
 const (
-	// IonicArchiveID ...
-	IonicArchiveID = "ionic-archive"
-	// IonicArchiveVersion ...
+	IonicArchiveID      = "ionic-archive"
 	IonicArchiveVersion = "2"
 )
 
 const (
-	// GenerateCordovaBuildConfigID ...
-	GenerateCordovaBuildConfigID = "generate-cordova-build-configuration"
-	// GenerateCordovaBuildConfigVersion ...
+	GenerateCordovaBuildConfigID      = "generate-cordova-build-configuration"
 	GenerateCordovaBuildConfigVersion = "0"
 )
 
 const (
-	// JasmineTestRunnerID ...
-	JasmineTestRunnerID = "jasmine-runner"
-	// JasmineTestRunnerVersion ...
+	JasmineTestRunnerID      = "jasmine-runner"
 	JasmineTestRunnerVersion = "0"
 )
 
 const (
-	// KarmaJasmineTestRunnerID ...
-	KarmaJasmineTestRunnerID = "karma-jasmine-runner"
-	// KarmaJasmineTestRunnerVersion ...
+	KarmaJasmineTestRunnerID      = "karma-jasmine-runner"
 	KarmaJasmineTestRunnerVersion = "0"
 )
 
 const (
-	// NpmID ...
-	NpmID = "npm"
-	// NpmVersion ...
+	NpmID      = "npm"
 	NpmVersion = "1"
 )
 
 const (
-	// RunEASBuildID ...
-	RunEASBuildID = "run-eas-build"
-	// RunEASBuildVersion ...
+	RunEASBuildID      = "run-eas-build"
 	RunEASBuildVersion = "0"
 )
 
-// RunEASBuildPlatforms ...
 var RunEASBuildPlatforms = []string{"all", "android", "ios"}
 
 const (
-	// YarnID ...
-	YarnID = "yarn"
-	// YarnVersion ...
+	YarnID      = "yarn"
 	YarnVersion = "0"
 )
 
 const (
-	// FlutterInstallID ...
-	FlutterInstallID = "flutter-installer"
-	// FlutterInstallVersion ...
+	FlutterInstallID      = "flutter-installer"
 	FlutterInstallVersion = "0"
 )
 
 const (
-	// FlutterTestID ...
-	FlutterTestID = "flutter-test"
-	// FlutterTestVersion ...
+	FlutterTestID      = "flutter-test"
 	FlutterTestVersion = "1"
 )
 
 const (
-	// FlutterAnalyzeID ...
-	FlutterAnalyzeID = "flutter-analyze"
-	// FlutterAnalyzeVersion ...
+	FlutterAnalyzeID      = "flutter-analyze"
 	FlutterAnalyzeVersion = "0"
 )
 
 const (
-	// FlutterBuildID ...
-	FlutterBuildID = "flutter-build"
-	// FlutterBuildVersion ...
+	FlutterBuildID      = "flutter-build"
 	FlutterBuildVersion = "0"
 )

--- a/steps/steps.go
+++ b/steps/steps.go
@@ -9,7 +9,7 @@ import (
 
 // PrepareListParams describes the default prepare Step options.
 type PrepareListParams struct {
-	ShouldIncludeCache       bool
+	ShouldIncludeLegacyCache bool
 	ShouldIncludeActivateSSH bool
 }
 
@@ -37,7 +37,6 @@ func stepListItem(stepIDComposite, title, runIf string, inputs ...envmanModels.E
 	}
 }
 
-// DefaultPrepareStepList ...
 func DefaultPrepareStepList(isIncludeCache bool) []bitriseModels.StepListItemModel {
 	runIfCondition := `{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}`
 	stepList := []bitriseModels.StepListItemModel{
@@ -52,7 +51,6 @@ func DefaultPrepareStepList(isIncludeCache bool) []bitriseModels.StepListItemMod
 	return append(stepList, ScriptSteplistItem(ScriptDefaultTitle))
 }
 
-// DefaultPrepareStepListV2 ...
 func DefaultPrepareStepListV2(params PrepareListParams) []bitriseModels.StepListItemModel {
 	stepList := []bitriseModels.StepListItemModel{}
 
@@ -62,14 +60,13 @@ func DefaultPrepareStepListV2(params PrepareListParams) []bitriseModels.StepList
 
 	stepList = append(stepList, GitCloneStepListItem())
 
-	if params.ShouldIncludeCache {
+	if params.ShouldIncludeLegacyCache {
 		stepList = append(stepList, CachePullStepListItem())
 	}
 
 	return stepList
 }
 
-// DefaultDeployStepList ...
 func DefaultDeployStepList(isIncludeCache bool) []bitriseModels.StepListItemModel {
 	stepList := []bitriseModels.StepListItemModel{
 		DeployToBitriseIoStepListItem(),
@@ -82,11 +79,10 @@ func DefaultDeployStepList(isIncludeCache bool) []bitriseModels.StepListItemMode
 	return stepList
 }
 
-// DefaultDeployStepListV2 ...
-func DefaultDeployStepListV2(shouldIncludeCache bool) []bitriseModels.StepListItemModel {
+func DefaultDeployStepListV2(shouldIncludeLegacyCache bool) []bitriseModels.StepListItemModel {
 	stepList := []bitriseModels.StepListItemModel{}
 
-	if shouldIncludeCache {
+	if shouldIncludeLegacyCache {
 		stepList = append(stepList, CachePushStepListItem())
 	}
 
@@ -95,175 +91,146 @@ func DefaultDeployStepListV2(shouldIncludeCache bool) []bitriseModels.StepListIt
 	return stepList
 }
 
-// ActivateSSHKeyStepListItem ...
 func ActivateSSHKeyStepListItem(runIfCondition string) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(ActivateSSHKeyID, ActivateSSHKeyVersion)
 	return stepListItem(stepIDComposite, "", runIfCondition)
 }
 
-// AndroidLintStepListItem ...
 func AndroidLintStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(AndroidLintID, AndroidLintVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// AndroidUnitTestStepListItem ...
 func AndroidUnitTestStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(AndroidUnitTestID, AndroidUnitTestVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// AndroidBuildStepListItem ...
 func AndroidBuildStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(AndroidBuildID, AndroidBuildVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// GitCloneStepListItem ...
 func GitCloneStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(GitCloneID, GitCloneVersion)
 	return stepListItem(stepIDComposite, "", "")
 }
 
-// CachePullStepListItem ...
 func CachePullStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(CachePullID, CachePullVersion)
 	return stepListItem(stepIDComposite, "", "")
 }
 
-// CachePushStepListItem ...
 func CachePushStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(CachePushID, CachePushVersion)
 	return stepListItem(stepIDComposite, "", "")
 }
 
-// CertificateAndProfileInstallerStepListItem ...
 func CertificateAndProfileInstallerStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(CertificateAndProfileInstallerID, CertificateAndProfileInstallerVersion)
 	return stepListItem(stepIDComposite, "", "")
 }
 
-// ChangeAndroidVersionCodeAndVersionNameStepListItem ...
 func ChangeAndroidVersionCodeAndVersionNameStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(ChangeAndroidVersionCodeAndVersionNameID, ChangeAndroidVersionCodeAndVersionNameVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// DeployToBitriseIoStepListItem ...
 func DeployToBitriseIoStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(DeployToBitriseIoID, DeployToBitriseIoVersion)
 	return stepListItem(stepIDComposite, "", "")
 }
 
-// ScriptSteplistItem ...
 func ScriptSteplistItem(title string, inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(ScriptID, ScriptVersion)
 	return stepListItem(stepIDComposite, title, "", inputs...)
 }
 
-// SignAPKStepListItem ...
 func SignAPKStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(SignAPKID, SignAPKVersion)
 	return stepListItem(stepIDComposite, "", `{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}`)
 }
 
-// InstallMissingAndroidToolsStepListItem ....
 func InstallMissingAndroidToolsStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(InstallMissingAndroidToolsID, InstallMissingAndroidToolsVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// FastlaneStepListItem ...
 func FastlaneStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(FastlaneID, FastlaneVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// CocoapodsInstallStepListItem ...
 func CocoapodsInstallStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(CocoapodsInstallID, CocoapodsInstallVersion)
 	return stepListItem(stepIDComposite, "", "")
 }
 
-// CarthageStepListItem ...
 func CarthageStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(CarthageID, CarthageVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// RecreateUserSchemesStepListItem ...
 func RecreateUserSchemesStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(RecreateUserSchemesID, RecreateUserSchemesVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// XcodeArchiveStepListItem ...
 func XcodeArchiveStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(XcodeArchiveID, XcodeArchiveVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// XcodeBuildForTestStepListItem ...
 func XcodeBuildForTestStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(XcodeBuildForTestID, XcodeBuildForTestVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// XcodeTestStepListItem ...
 func XcodeTestStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(XcodeTestID, XcodeTestVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// XcodeArchiveMacStepListItem ...
 func XcodeArchiveMacStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(XcodeArchiveMacID, XcodeArchiveMacVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// ExportXCArchiveStepListItem ...
 func ExportXCArchiveStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(ExportXCArchiveID, ExportXCArchiveVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// XcodeTestMacStepListItem ...
 func XcodeTestMacStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(XcodeTestMacID, XcodeTestMacVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// CordovaArchiveStepListItem ...
 func CordovaArchiveStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(CordovaArchiveID, CordovaArchiveVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// IonicArchiveStepListItem ...
 func IonicArchiveStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(IonicArchiveID, IonicArchiveVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// GenerateCordovaBuildConfigStepListItem ...
 func GenerateCordovaBuildConfigStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(GenerateCordovaBuildConfigID, GenerateCordovaBuildConfigVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// JasmineTestRunnerStepListItem ...
 func JasmineTestRunnerStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(JasmineTestRunnerID, JasmineTestRunnerVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// KarmaJasmineTestRunnerStepListItem ...
 func KarmaJasmineTestRunnerStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(KarmaJasmineTestRunnerID, KarmaJasmineTestRunnerVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// NpmStepListItem ...
 func NpmStepListItem(command, workdir string) bitriseModels.StepListItemModel {
 	var inputs []envmanModels.EnvironmentItemModel
 	if workdir != "" {
@@ -277,7 +244,6 @@ func NpmStepListItem(command, workdir string) bitriseModels.StepListItemModel {
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// RunEASBuildStepListItem ...
 func RunEASBuildStepListItem(workdir, platform string) bitriseModels.StepListItemModel {
 	var inputs []envmanModels.EnvironmentItemModel
 	if platform != "" {
@@ -290,7 +256,6 @@ func RunEASBuildStepListItem(workdir, platform string) bitriseModels.StepListIte
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// YarnStepListItem ...
 func YarnStepListItem(command, workdir string) bitriseModels.StepListItemModel {
 	var inputs []envmanModels.EnvironmentItemModel
 	if workdir != "" {
@@ -304,25 +269,21 @@ func YarnStepListItem(command, workdir string) bitriseModels.StepListItemModel {
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// FlutterInstallStepListItem ...
 func FlutterInstallStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(FlutterInstallID, FlutterInstallVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// FlutterTestStepListItem ...
 func FlutterTestStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(FlutterTestID, FlutterTestVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// FlutterAnalyzeStepListItem ...
 func FlutterAnalyzeStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(FlutterAnalyzeID, FlutterAnalyzeVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-// FlutterBuildStepListItem ...
 func FlutterBuildStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(FlutterBuildID, FlutterBuildVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)

--- a/steps/steps.go
+++ b/steps/steps.go
@@ -163,7 +163,9 @@ func FastlaneStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseMo
 
 func CocoapodsInstallStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(CocoapodsInstallID, CocoapodsInstallVersion)
-	return stepListItem(stepIDComposite, "", "")
+	return stepListItem(stepIDComposite, "", "", envmanModels.EnvironmentItemModel{
+		"is_cache_disabled": "true", // Disable legacy caching when used in workflows with KV caching
+	})
 }
 
 func CarthageStepListItem(inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {


### PR DESCRIPTION
### Changes

- Functional
  - Replace Cache Pull/Push steps in Android workflows with Restore/Save Gradle cache
  - Replace Cache Pull/Push steps in iOS workflows with Restore/Save Cocoapods/Carthage cache
  - Remove cache steps from`deploy` workflows. Deploying to stores should probably run a clean build to maximize reproducibility and stability.
- Refactors and cleanups
  - Remove dummy comments on exported methods
  - Test cleanups

### Out of scope

Adding SPM cache steps. This needs new detection logic, but this PR is already large, so it will come in a future PR.

Other platforms are also out of scope for this PR.