### PR TITLE
Add NPM cache to JS platform workflows

### DIFF
--- a/_tests/integration/cordova_test.go
+++ b/_tests/integration/cordova_test.go
@@ -47,8 +47,10 @@ var sampleAppsCordovaWithJasmineVersions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.ScriptVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.JasmineTestRunnerVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -99,10 +101,12 @@ configs:
           - git-clone@%s: {}
           - script@%s:
               title: Do anything with Script step
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - command: install
           - jasmine-runner@%s: {}
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   cordova: []
@@ -125,8 +129,10 @@ var sampleAppsCordovaWithKarmaJasmineVersions = []interface{}{
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
 	steps.ScriptVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.KarmaJasmineTestRunnerVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -177,10 +183,12 @@ configs:
           - git-clone@%s: {}
           - script@%s:
               title: Do anything with Script step
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - command: install
           - karma-jasmine-runner@%s: {}
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   cordova: []

--- a/_tests/integration/cordova_test.go
+++ b/_tests/integration/cordova_test.go
@@ -36,7 +36,6 @@ var sampleAppsCordovaWithJasmineVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.NpmVersion,
 	steps.JasmineTestRunnerVersion,
@@ -46,7 +45,6 @@ var sampleAppsCordovaWithJasmineVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.JasmineTestRunnerVersion,
@@ -81,8 +79,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - npm@%s:
               inputs:
@@ -99,8 +95,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
@@ -118,7 +112,6 @@ var sampleAppsCordovaWithKarmaJasmineVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.NpmVersion,
 	steps.KarmaJasmineTestRunnerVersion,
@@ -128,7 +121,6 @@ var sampleAppsCordovaWithKarmaJasmineVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.KarmaJasmineTestRunnerVersion,
@@ -163,8 +155,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - npm@%s:
               inputs:
@@ -181,8 +171,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -30,7 +30,6 @@ var fastlaneVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FastlaneVersion,
 	steps.DeployToBitriseIoVersion,
@@ -121,8 +120,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - fastlane@%s:
               inputs:

--- a/_tests/integration/ionic_test.go
+++ b/_tests/integration/ionic_test.go
@@ -31,9 +31,11 @@ var ionic2Versions = []interface{}{
 	steps.GitCloneVersion,
 	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.GenerateCordovaBuildConfigVersion,
 	steps.IonicArchiveVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -75,6 +77,7 @@ configs:
           - script@%s:
               title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - workdir: $IONIC_WORK_DIR
@@ -85,6 +88,7 @@ configs:
               - platform: $IONIC_PLATFORM
               - target: emulator
               - workdir: $IONIC_WORK_DIR
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ionic: []

--- a/_tests/integration/ionic_test.go
+++ b/_tests/integration/ionic_test.go
@@ -29,7 +29,6 @@ var ionic2Versions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
@@ -74,8 +73,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - restore-npm-cache@%s: {}
           - npm@%s:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -64,9 +64,11 @@ var customConfigVersions = []interface{}{
 	steps.GitCloneVersion,
 	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.GenerateCordovaBuildConfigVersion,
 	steps.CordovaArchiveVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// fastlane
@@ -210,9 +212,11 @@ var customConfigVersions = []interface{}{
 	steps.GitCloneVersion,
 	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.GenerateCordovaBuildConfigVersion,
 	steps.IonicArchiveVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// ios
@@ -276,8 +280,10 @@ var customConfigVersions = []interface{}{
 	// default-react-native-config/primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// default-react-native-expo-config/deploy
@@ -292,8 +298,10 @@ var customConfigVersions = []interface{}{
 	// default-react-native-expo-config/primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -643,6 +651,7 @@ configs:
           - script@%s:
               title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - workdir: $CORDOVA_WORK_DIR
@@ -653,6 +662,7 @@ configs:
               - workdir: $CORDOVA_WORK_DIR
               - platform: $CORDOVA_PLATFORM
               - target: emulator
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
   fastlane:
     default-fastlane-android-config: |
@@ -1009,6 +1019,7 @@ configs:
           - script@%s:
               title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - workdir: $IONIC_WORK_DIR
@@ -1019,6 +1030,7 @@ configs:
               - workdir: $IONIC_WORK_DIR
               - platform: $IONIC_PLATFORM
               - target: emulator
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
   ios:
     default-ios-config: |
@@ -1187,12 +1199,14 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - yarn@%s:
               inputs:
               - command: install
           - yarn@%s:
               inputs:
               - command: test
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
     default-react-native-expo-config: |
       format_version: "%s"
@@ -1232,6 +1246,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - yarn@%s:
               inputs:
               - workdir: $WORKDIR
@@ -1240,5 +1255,6 @@ configs:
               inputs:
               - workdir: $WORKDIR
               - command: test
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 `, customConfigVersions...)

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -62,7 +62,6 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
@@ -75,14 +74,12 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.FastlaneVersion,
 	steps.DeployToBitriseIoVersion,
 
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.FastlaneVersion,
 	steps.DeployToBitriseIoVersion,
@@ -210,7 +207,6 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.CertificateAndProfileInstallerVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
@@ -262,7 +258,6 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.ScriptVersion,
 	steps.DeployToBitriseIoVersion,
 
 	// react native
@@ -648,8 +643,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - restore-npm-cache@%s: {}
           - npm@%s:
@@ -678,8 +671,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - fastlane@%s:
               inputs:
               - lane: $FASTLANE_LANE
@@ -699,8 +690,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - fastlane@%s:
               inputs:
@@ -1016,8 +1005,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - certificate-and-profile-installer@%s: {}
           - restore-npm-cache@%s: {}
           - npm@%s:
@@ -1149,8 +1136,6 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - script@%s:
-              title: Do anything with Script step
           - deploy-to-bitrise-io@%s: {}
   react-native:
     default-react-native-config: |

--- a/_tests/integration/reactnative_expo_test.go
+++ b/_tests/integration/reactnative_expo_test.go
@@ -50,7 +50,9 @@ var managedExpoVersions = []interface{}{
 	// primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -102,9 +104,11 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - yarn@%s:
               inputs:
               - command: install
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
@@ -124,8 +128,10 @@ var managedExpo2Versions = []interface{}{
 	// primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -179,12 +185,14 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - yarn@%s:
               inputs:
               - command: install
           - yarn@%s:
               inputs:
               - command: test
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
@@ -205,8 +213,10 @@ var sampleAppsExpoBareVersions = []interface{}{
 	// primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -260,12 +270,14 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - yarn@%s:
               inputs:
               - command: install
           - yarn@%s:
               inputs:
               - command: test
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -129,8 +129,10 @@ var sampleAppsReactNativeSubdirVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.NpmVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -270,6 +272,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - workdir: $WORKDIR
@@ -278,6 +281,7 @@ configs:
               inputs:
               - workdir: $WORKDIR
               - command: test
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
@@ -299,8 +303,10 @@ var sampleAppsReactNativeIosAndAndroidVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.NpmVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -440,6 +446,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - workdir: $WORKDIR
@@ -448,6 +455,7 @@ configs:
               inputs:
               - workdir: $WORKDIR
               - command: test
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
@@ -468,7 +476,9 @@ var sampleAppsReactNativeIosAndAndroidNoTestVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -605,10 +615,12 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - workdir: $WORKDIR
               - command: install
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
@@ -630,8 +642,10 @@ var sampleAppsReactNativeIosAndAndroidYarnVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -771,6 +785,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - yarn@%s:
               inputs:
               - workdir: $WORKDIR
@@ -779,6 +794,7 @@ configs:
               inputs:
               - workdir: $WORKDIR
               - command: test
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []
@@ -800,7 +816,9 @@ var sampleAppsReactNativeJoplinVersions = []interface{}{
 
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
+	steps.CacheSaveNPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 
@@ -958,10 +976,12 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-npm-cache@%s: {}
           - npm@%s:
               inputs:
               - workdir: $WORKDIR
               - command: install
+          - save-npm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   react-native: []

--- a/scanners/cordova/cordova.go
+++ b/scanners/cordova/cordova.go
@@ -281,7 +281,6 @@ func (*Scanner) DefaultOptions() models.OptionNode {
 	return *workDirOption
 }
 
-// Configs ...
 func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(false)...)

--- a/scanners/cordova/cordova.go
+++ b/scanners/cordova/cordova.go
@@ -294,6 +294,7 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 	}
 
 	if scanner.hasJasmineTest || scanner.hasKarmaJasmineTest {
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem("install", workdir))
 
 		// CI
@@ -302,6 +303,7 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 		} else if scanner.hasJasmineTest {
 			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.JasmineTestRunnerStepListItem(workdirEnvList...))
 		}
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
 
 		// CD
@@ -319,8 +321,8 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.GenerateCordovaBuildConfigStepListItem())
 
 		cordovaArchiveEnvs := []envmanModels.EnvironmentItemModel{
-			envmanModels.EnvironmentItemModel{platformInputKey: "$" + platformInputEnvKey},
-			envmanModels.EnvironmentItemModel{targetInputKey: targetEmulator},
+			{platformInputKey: "$" + platformInputEnvKey},
+			{targetInputKey: targetEmulator},
 		}
 		if scanner.relCordovaConfigDir != "" {
 			cordovaArchiveEnvs = append(cordovaArchiveEnvs, envmanModels.EnvironmentItemModel{workDirInputKey: "$" + workDirInputEnvKey})
@@ -344,18 +346,20 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 	}
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem("install", workdir))
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.GenerateCordovaBuildConfigStepListItem())
 
 	cordovaArchiveEnvs := []envmanModels.EnvironmentItemModel{
-		envmanModels.EnvironmentItemModel{platformInputKey: "$" + platformInputEnvKey},
-		envmanModels.EnvironmentItemModel{targetInputKey: targetEmulator},
+		{platformInputKey: "$" + platformInputEnvKey},
+		{targetInputKey: targetEmulator},
 	}
 	if scanner.relCordovaConfigDir != "" {
 		cordovaArchiveEnvs = append(cordovaArchiveEnvs, envmanModels.EnvironmentItemModel{workDirInputKey: "$" + workDirInputEnvKey})
 	}
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CordovaArchiveStepListItem(cordovaArchiveEnvs...))
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
 
 	config, err := configBuilder.Generate(ScannerName)
@@ -380,6 +384,8 @@ func (*Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
 
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
+
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem("install", "$"+workDirInputEnvKey))
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.GenerateCordovaBuildConfigStepListItem())
@@ -388,6 +394,8 @@ func (*Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 		envmanModels.EnvironmentItemModel{workDirInputKey: "$" + workDirInputEnvKey},
 		envmanModels.EnvironmentItemModel{platformInputKey: "$" + platformInputEnvKey},
 		envmanModels.EnvironmentItemModel{targetInputKey: targetEmulator}))
+
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
 

--- a/scanners/ionic/ionic.go
+++ b/scanners/ionic/ionic.go
@@ -288,6 +288,7 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 	}
 
 	if scanner.hasJasmineTest || scanner.hasKarmaJasmineTest {
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem("install", workdir))
 
 		// CI
@@ -296,6 +297,7 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 		} else if scanner.hasJasmineTest {
 			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.JasmineTestRunnerStepListItem(workdirEnvList...))
 		}
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
 
 		// CD
@@ -338,6 +340,7 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 	}
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem("install", workdir))
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.GenerateCordovaBuildConfigStepListItem())
@@ -350,6 +353,7 @@ func (scanner *Scanner) Configs(_ bool) (models.BitriseConfigMap, error) {
 		ionicArchiveEnvs = append(ionicArchiveEnvs, envmanModels.EnvironmentItemModel{workDirInputKey: "$" + workDirInputEnvKey})
 	}
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.IonicArchiveStepListItem(ionicArchiveEnvs...))
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
 
 	config, err := configBuilder.Generate(scannerName)
@@ -374,6 +378,8 @@ func (Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
 
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
+
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.NpmStepListItem("install", "$"+workDirInputEnvKey))
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.GenerateCordovaBuildConfigStepListItem())
@@ -381,6 +387,8 @@ func (Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 		envmanModels.EnvironmentItemModel{workDirInputKey: "$" + workDirInputEnvKey},
 		envmanModels.EnvironmentItemModel{platformInputKey: "$" + platformInputEnvKey},
 		envmanModels.EnvironmentItemModel{targetInputKey: targetEmulator}))
+
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList(false)...)
 

--- a/scanners/reactnative/expo.go
+++ b/scanners/reactnative/expo.go
@@ -55,8 +55,9 @@ func (scanner *Scanner) expoConfigs(project project, isPrivateRepo bool) (models
 		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: isPrivateRepo,
 	})...)
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, testSteps...)
-
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(false)...)
 
 	// deploy workflow
@@ -115,7 +116,9 @@ func (scanner Scanner) expoDefaultConfigs() (models.BitriseConfigMap, error) {
 		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: true,
 	})...)
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, getTestSteps("$"+expoProjectDirInputEnvKey, true, true)...)
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(false)...)
 
 	// deploy workflow

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -190,8 +190,9 @@ func (scanner *Scanner) configs(isPrivateRepo bool) (models.BitriseConfigMap, er
 			ShouldIncludeLegacyCache: false,
 			ShouldIncludeActivateSSH: isPrivateRepo,
 		})...)
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, testSteps...)
-
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(false)...)
 
 		// cd
@@ -271,8 +272,10 @@ func (scanner *Scanner) defaultConfigs() (models.BitriseConfigMap, error) {
 		ShouldIncludeLegacyCache: false,
 		ShouldIncludeActivateSSH: true,
 	})...)
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 	// Assuming project uses yarn and has tests
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, getTestSteps("", true, true)...)
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.SaveNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepListV2(false)...)
 
 	// deploy

--- a/steps/cachesteps.go
+++ b/steps/cachesteps.go
@@ -31,3 +31,13 @@ func SaveCarthageCache() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(CacheSaveCarthageID, CacheSaveCarthageVersion)
 	return stepListItem(stepIDComposite, "", "")
 }
+
+func RestoreNPMCache() bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(CacheRestoreNPMID, CacheRestoreNPMVersion)
+	return stepListItem(stepIDComposite, "", "")
+}
+
+func SaveNPMCache() bitriseModels.StepListItemModel {
+	stepIDComposite := stepIDComposite(CacheSaveNPMID, CacheSaveNPMVersion)
+	return stepListItem(stepIDComposite, "", "")
+}

--- a/steps/const.go
+++ b/steps/const.go
@@ -71,12 +71,6 @@ const (
 )
 
 const (
-	ScriptID           = "script"
-	ScriptVersion      = "1"
-	ScriptDefaultTitle = "Do anything with Script step"
-)
-
-const (
 	SignAPKID      = "sign-apk"
 	SignAPKVersion = "1"
 )

--- a/steps/const.go
+++ b/steps/const.go
@@ -42,6 +42,8 @@ const (
 	CacheRestoreCocoapodsVersion = "1"
 	CacheRestoreCarthageID       = "restore-carthage-cache"
 	CacheRestoreCarthageVersion  = "1"
+	CacheRestoreNPMID            = "restore-npm-cache"
+	CacheRestoreNPMVersion       = "1"
 
 	CacheSaveGradleID         = "save-gradle-cache"
 	CacheSaveGradleVersion    = "1"
@@ -49,6 +51,8 @@ const (
 	CacheSaveCocoapodsVersion = "1"
 	CacheSaveCarthageID       = "save-carthage-cache"
 	CacheSaveCarthageVersion  = "1"
+	CacheSaveNPMID            = "save-npm-cache"
+	CacheSaveNPMVersion       = "1"
 )
 
 const (

--- a/steps/steps.go
+++ b/steps/steps.go
@@ -48,7 +48,7 @@ func DefaultPrepareStepList(isIncludeCache bool) []bitriseModels.StepListItemMod
 		stepList = append(stepList, CachePullStepListItem())
 	}
 
-	return append(stepList, ScriptSteplistItem(ScriptDefaultTitle))
+	return stepList
 }
 
 func DefaultPrepareStepListV2(params PrepareListParams) []bitriseModels.StepListItemModel {
@@ -139,11 +139,6 @@ func ChangeAndroidVersionCodeAndVersionNameStepListItem(inputs ...envmanModels.E
 func DeployToBitriseIoStepListItem() bitriseModels.StepListItemModel {
 	stepIDComposite := stepIDComposite(DeployToBitriseIoID, DeployToBitriseIoVersion)
 	return stepListItem(stepIDComposite, "", "")
-}
-
-func ScriptSteplistItem(title string, inputs ...envmanModels.EnvironmentItemModel) bitriseModels.StepListItemModel {
-	stepIDComposite := stepIDComposite(ScriptID, ScriptVersion)
-	return stepListItem(stepIDComposite, title, "", inputs...)
 }
 
 func SignAPKStepListItem() bitriseModels.StepListItemModel {


### PR DESCRIPTION
### Changes

Add NPM cache steps to:

- React Native and Expo workflows
- Cordova workflows
- Ionic workflows

### Notes

NPM and Yarn steps have a legacy caching input, but both of them are off by default, so this PR doesn't add those inputs to the workflow.