### PR TITLE
Upgrade git-clone to latest major

### DIFF
--- a/steps/const.go
+++ b/steps/const.go
@@ -22,7 +22,7 @@ const (
 
 const (
 	GitCloneID      = "git-clone"
-	GitCloneVersion = "7"
+	GitCloneVersion = "8"
 )
 
 const (


### PR DESCRIPTION
Version 8 was a special release, there is no breaking change that we need to handle in the workflows.

https://github.com/bitrise-steplib/steps-git-clone/releases/tag/8.0.0