### PR TITLE
Trigger map default branch

### DIFF
--- a/_tests/integration/android_test.go
+++ b/_tests/integration/android_test.go
@@ -20,28 +20,28 @@ func TestAndroid(t *testing.T) {
 		{
 			"sample-apps-android-sdk22",
 			"https://github.com/bitrise-samples/sample-apps-android-sdk22.git",
-			"",
+			"master",
 			sampleAppsAndroid22ResultYML,
 			sampleAppsAndroid22Versions,
 		},
 		{
 			"android-non-executable-gradlew",
 			"https://github.com/bitrise-samples/android-non-executable-gradlew.git",
-			"",
+			"master",
 			androidNonExecutableGradlewResultYML,
 			androidNonExecutableGradlewVersions,
 		},
 		{
 			"android-sdk22-subdir",
 			"https://github.com/bitrise-samples/sample-apps-android-sdk22-subdir",
-			"",
+			"master",
 			sampleAppsAndroidSDK22SubdirResultYML,
 			sampleAppsAndroidSDK22SubdirVersions,
 		},
 		{
 			"android-gradle-kotlin-dsl",
 			"https://github.com/bitrise-samples/android-gradle-kotlin-dsl",
-			"",
+			"master",
 			sampleAppsKotlinDSLResultYML,
 			sampleAppsAndroidSDK22SubdirVersions,
 		},
@@ -55,9 +55,11 @@ func TestMissingGradlewWrapper(t *testing.T) {
 	testName := "android-sdk22-no-gradlew"
 	sampleAppDir := filepath.Join(tmpDir, testName)
 	sampleAppURL := "https://github.com/bitrise-samples/android-sdk22-no-gradlew.git"
+	sampleAppDefaultBranch := "master"
+
 	helper.GitClone(t, sampleAppDir, sampleAppURL)
 
-	_, err := scanner.GenerateAndWriteResults(sampleAppDir, sampleAppDir, output.YAMLFormat)
+	_, err := scanner.GenerateAndWriteResults(sampleAppDir, sampleAppDir, output.YAMLFormat, sampleAppDefaultBranch)
 	require.EqualError(t, err, "No known platform detected")
 
 	scanResultPth := filepath.Join(sampleAppDir, "result.yml")
@@ -127,7 +129,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -277,7 +279,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -400,7 +402,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -503,7 +505,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/_tests/integration/cordova_test.go
+++ b/_tests/integration/cordova_test.go
@@ -14,14 +14,14 @@ func TestCordova(t *testing.T) {
 		{
 			"sample-apps-cordova-with-jasmine",
 			"https://github.com/bitrise-samples/sample-apps-cordova-with-jasmine.git",
-			"",
+			"master",
 			sampleAppsCordovaWithJasmineResultYML,
 			sampleAppsCordovaWithJasmineVersions,
 		},
 		{
 			"sample-apps-cordova-with-karma-jasmine",
 			"https://github.com/bitrise-samples/sample-apps-cordova-with-karma-jasmine.git",
-			"",
+			"master",
 			sampleAppsCordovaWithKarmaJasmineResultYML,
 			sampleAppsCordovaWithKarmaJasmineVersions,
 		},
@@ -74,7 +74,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: cordova
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -153,7 +153,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: cordova
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -14,7 +14,7 @@ func TestFastlane(t *testing.T) {
 		{
 			"fastlane",
 			"https://github.com/bitrise-samples/fastlane.git",
-			"",
+			"master",
 			fastlaneResultYML,
 			fastlaneVersions,
 		},
@@ -115,7 +115,7 @@ configs:
         envs:
         - FASTLANE_XCODE_LIST_TIMEOUT: "120"
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -137,7 +137,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/_tests/integration/flutter_test.go
+++ b/_tests/integration/flutter_test.go
@@ -14,21 +14,21 @@ func TestFlutter(t *testing.T) {
 		{
 			"sample-apps-flutter-ios-android",
 			"https://github.com/bitrise-samples/sample-apps-flutter-ios-android.git",
-			"",
+			"master",
 			flutterSampleAppResultYML,
 			flutterSampleAppVersions,
 		},
 		{
 			"sample-apps-flutter-ios-android-package",
 			"https://github.com/bitrise-samples/sample-apps-flutter-ios-android-package.git",
-			"",
+			"master",
 			flutterSamplePackageResultYML,
 			flutterSamplePackageVersions,
 		},
 		{
 			"sample-apps-flutter-ios-android-plugin",
 			"https://github.com/bitrise-samples/sample-apps-flutter-ios-android-plugin.git",
-			"",
+			"master",
 			flutterSamplePluginResultYML,
 			flutterSamplePluginVersions,
 		},
@@ -78,7 +78,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -167,7 +167,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -255,7 +255,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -308,7 +308,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/_tests/integration/helper/execution.go
+++ b/_tests/integration/helper/execution.go
@@ -32,7 +32,7 @@ func Execute(t *testing.T, testCases []TestCase) {
 				GitClone(t, sampleAppDir, testCase.RepoURL)
 			}
 
-			_, err := scanner.GenerateAndWriteResults(sampleAppDir, sampleAppDir, output.YAMLFormat)
+			_, err := scanner.GenerateAndWriteResults(sampleAppDir, sampleAppDir, output.YAMLFormat, testCase.Branch)
 			require.NoError(t, err)
 
 			scanResultPth := filepath.Join(sampleAppDir, "result.yml")

--- a/_tests/integration/ionic_test.go
+++ b/_tests/integration/ionic_test.go
@@ -14,7 +14,7 @@ func TestIonic(t *testing.T) {
 		{
 			"ionic-2",
 			"https://github.com/bitrise-samples/ionic-2.git",
-			"",
+			"master",
 			ionic2ResultYML,
 			ionic2Versions,
 		},
@@ -68,7 +68,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ionic
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -14,42 +14,42 @@ func TestIOS(t *testing.T) {
 		{
 			"ios-no-shared-schemes",
 			"https://github.com/bitrise-samples/ios-no-shared-schemes.git",
-			"",
+			"master",
 			iosNoSharedSchemesResultYML,
 			iosNoSharedSchemesVersions,
 		},
 		{
 			"ios-cocoapods-at-root",
 			"https://github.com/bitrise-samples/ios-cocoapods-at-root.git",
-			"",
+			"master",
 			iosCocoapodsAtRootResultYML,
 			iosCocoapodsAtRootVersions,
 		},
 		{
 			"sample-apps-ios-watchkit",
 			"https://github.com/bitrise-io/sample-apps-ios-watchkit.git",
-			"",
+			"master",
 			sampleAppsIosWatchkitResultYML,
 			sampleAppsIosWatchkitVersions,
 		},
 		{
 			"sample-apps-carthage",
 			"https://github.com/bitrise-samples/sample-apps-carthage.git",
-			"",
+			"master",
 			sampleAppsCarthageResultYML,
 			sampleAppsCarthageVersions,
 		},
 		{
 			"sample-apps-appclip",
 			"https://github.com/bitrise-io/sample-apps-ios-with-appclip.git",
-			"",
+			"main",
 			sampleAppClipResultYML,
 			sampleAppClipVersions,
 		},
 		{
 			"sample-apps-ios-swiftpm",
 			"https://github.com/bitrise-io/aci-xcode-spm-sample",
-			"",
+			"main",
 			sampleSPMResultYML,
 			sampleSPMVersions,
 		},
@@ -117,7 +117,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -248,7 +248,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -444,7 +444,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -490,7 +490,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -603,7 +603,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -762,7 +762,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: main
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -815,7 +815,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: main
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -861,7 +861,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: main
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -914,7 +914,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: main
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -1021,7 +1021,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
       trigger_map:
-      - push_branch: '*'
+      - push_branch: main
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/_tests/integration/mac_test.go
+++ b/_tests/integration/mac_test.go
@@ -14,7 +14,7 @@ func TestMacOS(t *testing.T) {
 		{
 			"sample-apps-osx-10-11",
 			"https://github.com/bitrise-samples/sample-apps-osx-10-11.git",
-			"",
+			"master",
 			sampleAppsOSX1011ResultYML,
 			sampleAppsOSX1011Versions,
 		},
@@ -84,7 +84,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: macos
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/_tests/integration/reactnative_expo_test.go
+++ b/_tests/integration/reactnative_expo_test.go
@@ -14,14 +14,14 @@ func TestReactNativeExpo(t *testing.T) {
 		{
 			"managed-workflow-no-tests",
 			"https://github.com/bitrise-io/sample-apps-expo.git",
-			"",
+			"master",
 			managedWorkflowNoTestsResultsYML,
 			managedExpoVersions,
 		},
 		{
 			"managed-workflow-with-tests",
 			"https://github.com/bitrise-io/Bitrise-React-Native-Expo-Sample.git",
-			"",
+			"master",
 			managedWorkflowResultsYML,
 			managedExpo2Versions,
 		},
@@ -76,7 +76,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -160,7 +160,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -250,7 +250,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
       trigger_map:
-      - push_branch: '*'
+      - push_branch: bare
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -46,21 +46,21 @@ func TestReactNative(t *testing.T) {
 		{
 			"joplin",
 			"https://github.com/bitrise-io/joplin.git",
-			"",
+			"dev",
 			sampleAppsReactNativeJoplinResultYML,
 			sampleAppsReactNativeJoplinVersions,
 		},
 		{
 			"sample-apps-react-native-ios-and-android",
 			simpleSample,
-			"",
+			"master",
 			sampleAppsReactNativeIosAndAndroidResultYML,
 			sampleAppsReactNativeIosAndAndroidVersions,
 		},
 		{
 			"sample-apps-react-native-subdir",
 			"https://github.com/bitrise-samples/sample-apps-react-native-subdir.git",
-			"",
+			"master",
 			sampleAppsReactNativeSubdirResultYML,
 			sampleAppsReactNativeSubdirVersions,
 		},
@@ -71,16 +71,18 @@ func TestReactNative(t *testing.T) {
 
 func TestNoTests(t *testing.T) {
 	testName := "sample-apps-react-native-ios-and-android-no-test"
+	defaultBranch := "master"
 	dir := setupSample(t, testName, simpleSample)
 
 	err := ioutil.WriteFile(filepath.Join(dir, "package.json"), []byte(noTestPackageJSON), 0600)
 	require.NoError(t, err)
 
-	generateAndValidateResult(t, testName, dir, sampleAppsReactNativeIosAndAndroidNoTestResultYML, sampleAppsReactNativeIosAndAndroidNoTestVersions)
+	generateAndValidateResult(t, testName, dir, sampleAppsReactNativeIosAndAndroidNoTestResultYML, sampleAppsReactNativeIosAndAndroidNoTestVersions, defaultBranch)
 }
 
 func TestYarn(t *testing.T) {
 	testName := "sample-apps-react-native-ios-and-android-yarn"
+	defaultBranch := "master"
 	dir := setupSample(t, testName, simpleSample)
 
 	yarnCommand := command.New("yarn", "install")
@@ -88,7 +90,7 @@ func TestYarn(t *testing.T) {
 	out, err := yarnCommand.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
 
-	generateAndValidateResult(t, testName, dir, sampleAppsReactNativeIosAndAndroidYarnResultYML, sampleAppsReactNativeIosAndAndroidYarnVersions)
+	generateAndValidateResult(t, testName, dir, sampleAppsReactNativeIosAndAndroidYarnResultYML, sampleAppsReactNativeIosAndAndroidYarnVersions, defaultBranch)
 }
 
 // Helpers
@@ -101,8 +103,8 @@ func setupSample(t *testing.T, name, repoURL string) string {
 	return sampleAppDir
 }
 
-func generateAndValidateResult(t *testing.T, name, dir, expectedResult string, expectedVersions []interface{}) {
-	_, err := scanner.GenerateAndWriteResults(dir, dir, output.YAMLFormat)
+func generateAndValidateResult(t *testing.T, name, dir, expectedResult string, expectedVersions []interface{}, defaultBranch string) {
+	_, err := scanner.GenerateAndWriteResults(dir, dir, output.YAMLFormat, defaultBranch)
 	require.NoError(t, err)
 
 	scanResultPth := filepath.Join(dir, "result.yml")
@@ -229,7 +231,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -408,7 +410,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -585,7 +587,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -757,7 +759,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
       trigger_map:
-      - push_branch: '*'
+      - push_branch: master
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary
@@ -953,7 +955,7 @@ configs:
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
       trigger_map:
-      - push_branch: '*'
+      - push_branch: dev
         workflow: primary
       - pull_request_source_branch: '*'
         workflow: primary

--- a/models/configbuilder.go
+++ b/models/configbuilder.go
@@ -24,12 +24,14 @@ const (
 
 // ConfigBuilderModel ...
 type ConfigBuilderModel struct {
+	defaultBranch      string
 	workflowBuilderMap map[WorkflowID]*workflowBuilderModel
 }
 
 // NewDefaultConfigBuilder ...
-func NewDefaultConfigBuilder() *ConfigBuilderModel {
+func NewDefaultConfigBuilder(defaultBranch string) *ConfigBuilderModel {
 	return &ConfigBuilderModel{
+		defaultBranch: defaultBranch,
 		workflowBuilderMap: map[WorkflowID]*workflowBuilderModel{
 			PrimaryWorkflowID: newDefaultWorkflowBuilder(),
 		},
@@ -68,9 +70,13 @@ func (builder *ConfigBuilderModel) Generate(projectType string, appEnvs ...envma
 		workflows[string(workflowID)] = workflowBuilder.generate()
 	}
 
+	pushBranchPattern := "*"
+	if builder.defaultBranch != "" {
+		pushBranchPattern = builder.defaultBranch
+	}
 	triggerMap := []bitriseModels.TriggerMapItemModel{
 		bitriseModels.TriggerMapItemModel{
-			PushBranch: "*",
+			PushBranch: pushBranchPattern,
 			WorkflowID: string(PrimaryWorkflowID),
 		},
 		bitriseModels.TriggerMapItemModel{

--- a/models/configbuilder_test.go
+++ b/models/configbuilder_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestConfigGenerateHaveProjectType(t *testing.T) {
-	config := NewDefaultConfigBuilder()
+	config := NewDefaultConfigBuilder("")
 	config.AppendStepListItemsTo("primary", []bitriseModels.StepListItemModel{
 		{"step-id": stepmanModels.StepModel{}},
 	}...)
@@ -21,7 +21,7 @@ func TestConfigGenerateHaveProjectType(t *testing.T) {
 }
 
 func TestConfigGenerateHaveTriggerMap(t *testing.T) {
-	config := NewDefaultConfigBuilder()
+	config := NewDefaultConfigBuilder("main")
 	config.AppendStepListItemsTo("primary", []bitriseModels.StepListItemModel{
 		{"step-id": stepmanModels.StepModel{}},
 	}...)
@@ -29,5 +29,14 @@ func TestConfigGenerateHaveTriggerMap(t *testing.T) {
 	model, err := config.Generate("iOS")
 
 	require.Nil(t, err)
-	require.Equal(t, 2, len(model.TriggerMap))
+	require.Equal(t, bitriseModels.TriggerMapModel{
+		bitriseModels.TriggerMapItemModel{
+			PushBranch: "main",
+			WorkflowID: "primary",
+		},
+		bitriseModels.TriggerMapItemModel{
+			PullRequestSourceBranch: "*",
+			WorkflowID:              "primary",
+		},
+	}, model.TriggerMap)
 }

--- a/scanner/config.go
+++ b/scanner/config.go
@@ -87,7 +87,7 @@ func (o *scannerOutput) AddWarnings(tag string, errs ...string) {
 }
 
 // Config ...
-func Config(searchDir string, isPrivateRepository bool) models.ScanResultModel {
+func Config(searchDir string, isPrivateRepository bool, defaultBranch string) models.ScanResultModel {
 	result := models.ScanResultModel{}
 
 	//
@@ -146,7 +146,7 @@ func Config(searchDir string, isPrivateRepository bool) models.ScanResultModel {
 	fmt.Println()
 
 	// Collect scanner outputs, by scanner name
-	projectScannerToOutputs := runScanners(scanners.ProjectScanners(), searchDir, isPrivateRepository)
+	projectScannerToOutputs := runScanners(scanners.ProjectScanners(), searchDir, isPrivateRepository, defaultBranch)
 	detectedProjectTypes := getDetectedScannerNames(projectScannerToOutputs)
 	log.Printf("Detected project types: %s", detectedProjectTypes)
 	fmt.Println()
@@ -163,7 +163,7 @@ func Config(searchDir string, isPrivateRepository bool) models.ScanResultModel {
 		toolScanner.(scanners.AutomationToolScanner).SetDetectedProjectTypes(detectedProjectTypes)
 	}
 
-	scannerToOutput := runScanners(automationToolScanners, searchDir, isPrivateRepository)
+	scannerToOutput := runScanners(automationToolScanners, searchDir, isPrivateRepository, defaultBranch)
 	detectedAutomationToolScanners := getDetectedScannerNames(scannerToOutput)
 	log.Printf("Detected automation tools: %s", detectedAutomationToolScanners)
 	fmt.Println()
@@ -212,7 +212,7 @@ func Config(searchDir string, isPrivateRepository bool) models.ScanResultModel {
 	}
 }
 
-func runScanners(scannerList []scanners.ScannerInterface, searchDir string, isPrivateRepository bool) map[string]scannerOutput {
+func runScanners(scannerList []scanners.ScannerInterface, searchDir string, isPrivateRepository bool, defaultBranch string) map[string]scannerOutput {
 	scannerOutputs := map[string]scannerOutput{}
 	var excludedScannerNames []string
 	for _, scanner := range scannerList {
@@ -225,7 +225,7 @@ func runScanners(scannerList []scanners.ScannerInterface, searchDir string, isPr
 
 		log.TPrintf("+------------------------------------------------------------------------------+")
 		log.TPrintf("|                                                                              |")
-		scannerOutput := runScanner(scanner, searchDir, isPrivateRepository)
+		scannerOutput := runScanner(scanner, searchDir, isPrivateRepository, defaultBranch)
 		log.TPrintf("|                                                                              |")
 		log.TPrintf("+------------------------------------------------------------------------------+")
 		fmt.Println()
@@ -237,7 +237,7 @@ func runScanners(scannerList []scanners.ScannerInterface, searchDir string, isPr
 }
 
 // Collect output of a specific scanner
-func runScanner(detector scanners.ScannerInterface, searchDir string, isPrivateRepository bool) scannerOutput {
+func runScanner(detector scanners.ScannerInterface, searchDir string, isPrivateRepository bool, defaultBranch string) scannerOutput {
 	output := scannerOutput{}
 
 	if isDetect, err := detector.DetectPlatform(searchDir); err != nil {
@@ -280,7 +280,7 @@ func runScanner(detector scanners.ScannerInterface, searchDir string, isPrivateR
 	} else {
 		repoAccess = models.RepoAccessPublic
 	}
-	configs, err := detector.Configs(repoAccess)
+	configs, err := detector.Configs(repoAccess, defaultBranch)
 	if err != nil {
 		data := detectorErrorData(detector.Name(), err)
 		analytics.LogError(configsFailedTag, data, "%s detector Configs failed", detector.Name())

--- a/scanner/result.go
+++ b/scanner/result.go
@@ -16,8 +16,8 @@ import (
 )
 
 // GenerateScanResult runs the scanner, returns the results and if any platform was detected.
-func GenerateScanResult(searchDir string, isPrivateRepository bool) (models.ScanResultModel, bool) {
-	scanResult := Config(searchDir, isPrivateRepository)
+func GenerateScanResult(searchDir string, isPrivateRepository bool, defaultBranch string) (models.ScanResultModel, bool) {
+	scanResult := Config(searchDir, isPrivateRepository, defaultBranch)
 
 	logUnknownTools(searchDir)
 
@@ -43,8 +43,8 @@ func GenerateScanResult(searchDir string, isPrivateRepository bool) (models.Scan
 }
 
 // GenerateAndWriteResults runs the scanner and saves results to the given output dir.
-func GenerateAndWriteResults(searchDir string, outputDir string, format output.Format) (models.ScanResultModel, error) {
-	result, detected := GenerateScanResult(searchDir, true)
+func GenerateAndWriteResults(searchDir string, outputDir string, format output.Format, defaultBranch string) (models.ScanResultModel, error) {
+	result, detected := GenerateScanResult(searchDir, true, defaultBranch)
 
 	// Write output to files
 	log.TInfof("Saving outputs:")

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -171,7 +171,7 @@ func (scanner *Scanner) DefaultOptions() models.OptionNode {
 }
 
 // Configs ...
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	configBuilder := scanner.generateConfigBuilder(repoAccess)
 
 	config, err := configBuilder.Generate(ScannerName)

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -172,7 +172,7 @@ func (scanner *Scanner) DefaultOptions() models.OptionNode {
 
 // Configs ...
 func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
-	configBuilder := scanner.generateConfigBuilder(repoAccess)
+	configBuilder := scanner.generateConfigBuilder(repoAccess, defaultBranch)
 
 	config, err := configBuilder.Generate(ScannerName)
 	if err != nil {
@@ -191,7 +191,7 @@ func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch stri
 
 // DefaultConfigs ...
 func (scanner *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
-	configBuilder := scanner.generateConfigBuilder(models.RepoAccessUnknown)
+	configBuilder := scanner.generateConfigBuilder(models.RepoAccessUnknown, "")
 
 	config, err := configBuilder.Generate(ScannerName)
 	if err != nil {

--- a/scanners/android/utility.go
+++ b/scanners/android/utility.go
@@ -141,8 +141,8 @@ that the right Gradle version is installed and used for the build. More info/gui
 	return nil
 }
 
-func (scanner *Scanner) generateConfigBuilder(repoAccess models.RepoAccess) models.ConfigBuilderModel {
-	configBuilder := models.NewDefaultConfigBuilder()
+func (scanner *Scanner) generateConfigBuilder(repoAccess models.RepoAccess, defaultBranch string) models.ConfigBuilderModel {
+	configBuilder := models.NewDefaultConfigBuilder(defaultBranch)
 
 	projectLocationEnv, gradlewPath, moduleEnv, variantEnv := "$"+ProjectLocationInputEnvKey, "$"+ProjectLocationInputEnvKey+"/gradlew", "$"+ModuleInputEnvKey, "$"+VariantInputEnvKey
 

--- a/scanners/cordova/cordova.go
+++ b/scanners/cordova/cordova.go
@@ -282,7 +282,7 @@ func (*Scanner) DefaultOptions() models.OptionNode {
 }
 
 func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder(defaultBranch)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 		RepoAccess: repoAccess,
 	})...)
@@ -382,7 +382,7 @@ func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch stri
 
 // DefaultConfigs ...
 func (*Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder("")
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 		RepoAccess: models.RepoAccessUnknown,
 	})...)

--- a/scanners/cordova/cordova.go
+++ b/scanners/cordova/cordova.go
@@ -281,7 +281,7 @@ func (*Scanner) DefaultOptions() models.OptionNode {
 	return *workDirOption
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 		RepoAccess: repoAccess,

--- a/scanners/fastlane/fastlane.go
+++ b/scanners/fastlane/fastlane.go
@@ -192,7 +192,7 @@ func (*Scanner) DefaultOptions() models.OptionNode {
 
 func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	generateConfig := func(isIOS bool) (bitriseModels.BitriseDataModel, error) {
-		configBuilder := models.NewDefaultConfigBuilder()
+		configBuilder := models.NewDefaultConfigBuilder(defaultBranch)
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 			RepoAccess: repoAccess,
 		})...)
@@ -245,7 +245,7 @@ func (*Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 	configMap := models.BitriseConfigMap{}
 
 	for _, p := range platforms {
-		configBuilder := models.NewDefaultConfigBuilder()
+		configBuilder := models.NewDefaultConfigBuilder("")
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{RepoAccess: models.RepoAccessUnknown})...)
 
 		if p == iosPlatform {

--- a/scanners/fastlane/fastlane.go
+++ b/scanners/fastlane/fastlane.go
@@ -190,7 +190,7 @@ func (*Scanner) DefaultOptions() models.OptionNode {
 	return *workDirOption
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	generateConfig := func(isIOS bool) (bitriseModels.BitriseDataModel, error) {
 		configBuilder := models.NewDefaultConfigBuilder()
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{

--- a/scanners/flutter/flutter.go
+++ b/scanners/flutter/flutter.go
@@ -189,7 +189,7 @@ func (scanner *Scanner) DefaultOptions() models.OptionNode {
 	return *flutterProjectLocationOption
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	configs := models.BitriseConfigMap{}
 
 	for _, proj := range scanner.projects {

--- a/scanners/flutter/flutter.go
+++ b/scanners/flutter/flutter.go
@@ -193,7 +193,7 @@ func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch stri
 	configs := models.BitriseConfigMap{}
 
 	for _, proj := range scanner.projects {
-		config, err := generateConfig(repoAccess, proj)
+		config, err := generateConfig(proj, repoAccess, defaultBranch)
 		if err != nil {
 			return nil, err
 		}
@@ -210,7 +210,7 @@ func (scanner *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 	for i, proj := range defaultProjects {
 		proj.id = i
 
-		config, err := generateConfig(models.RepoAccessUnknown, proj)
+		config, err := generateConfig(proj, models.RepoAccessUnknown, "")
 		if err != nil {
 			return nil, err
 		}
@@ -243,8 +243,8 @@ func findProjectLocations(searchDir string) ([]string, error) {
 	return paths, nil
 }
 
-func generateConfig(repoAccess models.RepoAccess, proj project) (string, error) {
-	configBuilder := models.NewDefaultConfigBuilder()
+func generateConfig(proj project, repoAccess models.RepoAccess, defaultBranch string) (string, error) {
+	configBuilder := models.NewDefaultConfigBuilder(defaultBranch)
 
 	// Common steps to all workflows
 	prepareSteps := steps.DefaultPrepareStepList(steps.PrepareListParams{RepoAccess: repoAccess})

--- a/scanners/ionic/ionic.go
+++ b/scanners/ionic/ionic.go
@@ -275,7 +275,7 @@ func (Scanner) DefaultOptions() models.OptionNode {
 	return *workDirOption
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 		RepoAccess: repoAccess,

--- a/scanners/ionic/ionic.go
+++ b/scanners/ionic/ionic.go
@@ -276,7 +276,7 @@ func (Scanner) DefaultOptions() models.OptionNode {
 }
 
 func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder(defaultBranch)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 		RepoAccess: repoAccess,
 	})...)
@@ -373,7 +373,7 @@ func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch stri
 }
 
 func (Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder("")
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{RepoAccess: models.RepoAccessUnknown})...)
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())

--- a/scanners/ios/ios.go
+++ b/scanners/ios/ios.go
@@ -62,7 +62,7 @@ func (Scanner) DefaultOptions() models.OptionNode {
 	return GenerateDefaultOptions(XcodeProjectTypeIOS)
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	return GenerateConfig(XcodeProjectTypeIOS, scanner.ConfigDescriptors, repoAccess)
 }
 

--- a/scanners/ios/ios.go
+++ b/scanners/ios/ios.go
@@ -63,7 +63,7 @@ func (Scanner) DefaultOptions() models.OptionNode {
 }
 
 func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
-	return GenerateConfig(XcodeProjectTypeIOS, scanner.ConfigDescriptors, repoAccess)
+	return GenerateConfig(XcodeProjectTypeIOS, scanner.ConfigDescriptors, repoAccess, defaultBranch)
 }
 
 // DefaultConfigs ...

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -558,6 +558,7 @@ func GenerateDefaultOptions(projectType XcodeProjectType) models.OptionNode {
 func GenerateConfigBuilder(
 	projectType XcodeProjectType,
 	repoAccess models.RepoAccess,
+	defaultBranch string,
 	hasPodfile,
 	hasTest,
 	hasAppClip,
@@ -566,7 +567,7 @@ func GenerateConfigBuilder(
 	carthageCommand,
 	exportMethod string,
 ) models.ConfigBuilderModel {
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder(defaultBranch)
 
 	params := workflowSetupParams{
 		projectType:          projectType,
@@ -602,12 +603,13 @@ func RemoveDuplicatedConfigDescriptors(configDescriptors []ConfigDescriptor, pro
 	return descriptors
 }
 
-func GenerateConfig(projectType XcodeProjectType, configDescriptors []ConfigDescriptor, repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func GenerateConfig(projectType XcodeProjectType, configDescriptors []ConfigDescriptor, repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	bitriseDataMap := models.BitriseConfigMap{}
 	for _, descriptor := range configDescriptors {
 		configBuilder := GenerateConfigBuilder(
 			projectType,
 			repoAccess,
+			defaultBranch,
 			descriptor.HasPodfile,
 			descriptor.HasTest,
 			descriptor.HasAppClip,
@@ -636,6 +638,7 @@ func GenerateDefaultConfig(projectType XcodeProjectType) (models.BitriseConfigMa
 	configBuilder := GenerateConfigBuilder(
 		projectType,
 		models.RepoAccessUnknown,
+		"",
 		true,
 		true,
 		false,

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -59,7 +59,7 @@ func (Scanner) DefaultOptions() models.OptionNode {
 	return ios.GenerateDefaultOptions(ios.XcodeProjectTypeMacOS)
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	return ios.GenerateConfig(ios.XcodeProjectTypeMacOS, scanner.configDescriptors, repoAccess)
 }
 

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -60,7 +60,7 @@ func (Scanner) DefaultOptions() models.OptionNode {
 }
 
 func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
-	return ios.GenerateConfig(ios.XcodeProjectTypeMacOS, scanner.configDescriptors, repoAccess)
+	return ios.GenerateConfig(ios.XcodeProjectTypeMacOS, scanner.configDescriptors, repoAccess, defaultBranch)
 }
 
 func (Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {

--- a/scanners/reactnative/expo.go
+++ b/scanners/reactnative/expo.go
@@ -34,7 +34,7 @@ func (scanner *Scanner) expoOptions() models.OptionNode {
 }
 
 // expoConfigs implements ScannerInterface.Configs function for Expo based React Native projects.
-func (scanner *Scanner) expoConfigs(project project, repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) expoConfigs(project project, repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	configMap := models.BitriseConfigMap{}
 
 	if project.projectRelDir == "." {
@@ -49,7 +49,7 @@ func (scanner *Scanner) expoConfigs(project project, repoAccess models.RepoAcces
 		primaryDescription = expoPrimaryWorkflowNoTestsDescription
 	}
 
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder(defaultBranch)
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryDescription)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 		RepoAccess: repoAccess,
@@ -108,7 +108,7 @@ func (scanner Scanner) expoDefaultConfigs() (models.BitriseConfigMap, error) {
 	configMap := models.BitriseConfigMap{}
 
 	// primary workflow
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder("")
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, expoPrimaryWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 		RepoAccess: models.RepoAccessUnknown,

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -167,7 +167,7 @@ func (scanner *Scanner) defaultOptions() models.OptionNode {
 	return *androidOptions
 }
 
-func (scanner *Scanner) configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	configMap := models.BitriseConfigMap{}
 
 	if len(scanner.configDescriptors) == 0 {
@@ -175,7 +175,7 @@ func (scanner *Scanner) configs(repoAccess models.RepoAccess) (models.BitriseCon
 	}
 
 	for _, descriptor := range scanner.configDescriptors {
-		configBuilder := models.NewDefaultConfigBuilder()
+		configBuilder := models.NewDefaultConfigBuilder(defaultBranch)
 
 		testSteps := getTestSteps("$"+projectDirInputEnvKey, descriptor.hasYarnLockFile, descriptor.hasTest)
 		// ci
@@ -260,7 +260,7 @@ func (scanner *Scanner) configs(repoAccess models.RepoAccess) (models.BitriseCon
 }
 
 func (scanner *Scanner) defaultConfigs() (models.BitriseConfigMap, error) {
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder("")
 
 	// primary
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryWorkflowDescription)

--- a/scanners/reactnative/reactnative.go
+++ b/scanners/reactnative/reactnative.go
@@ -254,10 +254,10 @@ func (scanner *Scanner) Options() (options models.OptionNode, allWarnings models
 
 func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	if scanner.isExpoBased {
-		return scanner.expoConfigs(scanner.projects[0], repoAccess)
+		return scanner.expoConfigs(scanner.projects[0], repoAccess, defaultBranch)
 	}
 
-	return scanner.configs(repoAccess)
+	return scanner.configs(repoAccess, defaultBranch)
 }
 
 // DefaultOptions implements ScannerInterface.DefaultOptions function.

--- a/scanners/reactnative/reactnative.go
+++ b/scanners/reactnative/reactnative.go
@@ -252,7 +252,7 @@ func (scanner *Scanner) Options() (options models.OptionNode, allWarnings models
 	return
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error) {
 	if scanner.isExpoBased {
 		return scanner.expoConfigs(scanner.projects[0], repoAccess)
 	}

--- a/scanners/scanners.go
+++ b/scanners/scanners.go
@@ -95,7 +95,7 @@ const CustomConfigName = "other-config"
 
 // CustomConfig ...
 func CustomConfig() (models.BitriseConfigMap, error) {
-	configBuilder := models.NewDefaultConfigBuilder()
+	configBuilder := models.NewDefaultConfigBuilder("")
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
 		RepoAccess: models.RepoAccessUnknown,
 	})...)

--- a/scanners/scanners.go
+++ b/scanners/scanners.go
@@ -53,7 +53,7 @@ type ScannerInterface interface {
 	// Every config's key should be the last option one of the OptionNode branches.
 	// Returns:
 	// - platform BitriseConfigMap
-	Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error)
+	Configs(repoAccess models.RepoAccess, defaultBranch string) (models.BitriseConfigMap, error)
 
 	// Returns:
 	// - platform default BitriseConfigMap


### PR DESCRIPTION
This PR updates the trigger map of the project scanner-generated configs.
The new trigger map will trigger a build for push events on the default branch, instead of push events on any branch. 
This will prevent triggering 2 builds when a pull request is opened.

Related task: https://bitrise.atlassian.net/browse/BIVS-1849