### PR TITLE
Remove trigger map from the generated configs

### DIFF
--- a/_tests/integration/android_test.go
+++ b/_tests/integration/android_test.go
@@ -126,11 +126,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -276,11 +271,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -399,11 +389,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -502,11 +487,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |

--- a/_tests/integration/cordova_test.go
+++ b/_tests/integration/cordova_test.go
@@ -73,11 +73,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: cordova
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           steps:
@@ -152,11 +147,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: cordova
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           steps:

--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -114,11 +114,6 @@ configs:
       app:
         envs:
         - FASTLANE_XCODE_LIST_TIMEOUT: "120"
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         primary:
           steps:
@@ -136,11 +131,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |

--- a/_tests/integration/flutter_test.go
+++ b/_tests/integration/flutter_test.go
@@ -77,11 +77,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -166,11 +161,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         primary:
           description: |
@@ -254,11 +244,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -307,11 +292,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |

--- a/_tests/integration/ionic_test.go
+++ b/_tests/integration/ionic_test.go
@@ -67,11 +67,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ionic
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         primary:
           steps:

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -116,11 +116,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -247,11 +242,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -443,11 +433,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -489,11 +474,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -602,11 +582,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -761,11 +736,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -814,11 +784,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -860,11 +825,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -913,11 +873,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -1020,11 +975,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |

--- a/_tests/integration/mac_test.go
+++ b/_tests/integration/mac_test.go
@@ -83,11 +83,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: macos
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           steps:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -518,11 +518,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: android
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -586,11 +581,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: cordova
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         primary:
           steps:
@@ -619,11 +609,6 @@ configs:
       app:
         envs:
         - FASTLANE_XCODE_LIST_TIMEOUT: "120"
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         primary:
           steps:
@@ -643,11 +628,6 @@ configs:
       app:
         envs:
         - FASTLANE_XCODE_LIST_TIMEOUT: "120"
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         primary:
           steps:
@@ -666,11 +646,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -722,11 +697,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -780,11 +750,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: flutter
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -839,11 +804,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ionic
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         primary:
           steps:
@@ -869,11 +829,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -940,11 +895,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: macos
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           steps:
@@ -993,11 +943,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: other
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         primary:
           steps:
@@ -1010,11 +955,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -1072,11 +1012,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |

--- a/_tests/integration/reactnative_expo_test.go
+++ b/_tests/integration/reactnative_expo_test.go
@@ -75,11 +75,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -159,11 +154,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -249,11 +239,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -228,11 +228,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -407,11 +402,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -584,11 +574,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -756,11 +741,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |
@@ -952,11 +932,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: react-native
-      trigger_map:
-      - push_branch: '*'
-        workflow: primary
-      - pull_request_source_branch: '*'
-        workflow: primary
       workflows:
         deploy:
           description: |

--- a/models/configbuilder.go
+++ b/models/configbuilder.go
@@ -68,17 +68,6 @@ func (builder *ConfigBuilderModel) Generate(projectType string, appEnvs ...envma
 		workflows[string(workflowID)] = workflowBuilder.generate()
 	}
 
-	triggerMap := []bitriseModels.TriggerMapItemModel{
-		bitriseModels.TriggerMapItemModel{
-			PushBranch: "*",
-			WorkflowID: string(PrimaryWorkflowID),
-		},
-		bitriseModels.TriggerMapItemModel{
-			PullRequestSourceBranch: "*",
-			WorkflowID:              string(PrimaryWorkflowID),
-		},
-	}
-
 	app := bitriseModels.AppModel{
 		Environments: appEnvs,
 	}
@@ -87,7 +76,6 @@ func (builder *ConfigBuilderModel) Generate(projectType string, appEnvs ...envma
 		FormatVersion:        FormatVersion,
 		DefaultStepLibSource: defaultSteplibSource,
 		ProjectType:          projectType,
-		TriggerMap:           triggerMap,
 		Workflows:            workflows,
 		App:                  app,
 	}, nil

--- a/models/configbuilder_test.go
+++ b/models/configbuilder_test.go
@@ -20,7 +20,7 @@ func TestConfigGenerateHaveProjectType(t *testing.T) {
 	require.Equal(t, "iOS", model.ProjectType)
 }
 
-func TestConfigGenerateHaveTriggerMap(t *testing.T) {
+func TestConfigDoesNotGenerateTriggerMap(t *testing.T) {
 	config := NewDefaultConfigBuilder()
 	config.AppendStepListItemsTo("primary", []bitriseModels.StepListItemModel{
 		{"step-id": stepmanModels.StepModel{}},
@@ -29,5 +29,5 @@ func TestConfigGenerateHaveTriggerMap(t *testing.T) {
 	model, err := config.Generate("iOS")
 
 	require.Nil(t, err)
-	require.Equal(t, 2, len(model.TriggerMap))
+	require.Nil(t, model.TriggerMap)
 }


### PR DESCRIPTION
## Context

The currently generated app config has a trigger map configuration, that triggers two Bitrise builds when a Pull Request gets opened.

This is because the trigger map has a push-type trigger item, which triggers a build for every code push, and another item that triggers a build for every pull request-related event:

```
trigger_map:
- push_branch: '*'
  workflow: primary
- pull_request_source_branch: '*'
  workflow: primary
```

The expected trigger map triggers a single build when a pull request gets opened (unless you open a PR from the repository default branch) or code gets pushed to the default branch:

```
trigger_map:
- push_branch: <default_branch_name>
  workflow: primary
- pull_request_source_branch: '*'
  workflow: primary
```

This change couldn't be done on the project-scanner Step side fully, because the manual configs are not aware of the default branch.
To resolve this issue, adding a trigger map to the configs is moved to the website: https://github.com/bitrise-io/bitrise-website/pull/10528

## Changes

- Remove trigger map handling from the config builder
