### PR TITLE
[CI-1640] Add SPM project support

### DIFF
--- a/_tests/integration/fastlane_test.go
+++ b/_tests/integration/fastlane_test.go
@@ -73,9 +73,9 @@ var fastlaneResultYML = fmt.Sprintf(`options:
                 config: fastlane-config_ios
   ios:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: selector
     value_map:

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -85,9 +85,9 @@ var iosNoSharedSchemesVersions = []interface{}{
 var iosNoSharedSchemesResultYML = fmt.Sprintf(`options:
   ios:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: selector
     value_map:
@@ -211,9 +211,9 @@ var iosCocoapodsAtRootVersions = []interface{}{
 var iosCocoapodsAtRootResultYML = fmt.Sprintf(`options:
   ios:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: selector
     value_map:
@@ -334,9 +334,9 @@ var sampleAppsIosWatchkitVersions = []interface{}{
 var sampleAppsIosWatchkitResultYML = fmt.Sprintf(`options:
   ios:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: selector
     value_map:
@@ -551,9 +551,9 @@ var sampleAppsCarthageVersions = []interface{}{
 var sampleAppsCarthageResultYML = fmt.Sprintf(`options:
   ios:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: selector
     value_map:
@@ -705,9 +705,9 @@ var sampleAppClipVersions = []interface{}{
 var sampleAppClipResultYML = fmt.Sprintf(`options:
   ios:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: selector
     value_map:
@@ -944,9 +944,9 @@ var sampleSPMVersions = []interface{}{
 var sampleSPMResultYML = fmt.Sprintf(`options:
   ios:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: selector
     value_map:

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -1036,12 +1036,10 @@ warnings_with_recommendations:
 var sampleSPMProjectVersions = []interface{}{
 	models.FormatVersion,
 
-	// ios-spm-spm-project-test-config/primary
+	// ios-spm-project-test-config/primary
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.CacheRestoreSPMVersion,
 	steps.XcodeTestVersion,
-	steps.CacheSaveSPMVersion,
 	steps.DeployToBitriseIoVersion,
 }
 var sampleSPMProjectResultYML = fmt.Sprintf(`options:
@@ -1063,10 +1061,10 @@ var sampleSPMProjectResultYML = fmt.Sprintf(`options:
         type: selector
         value_map:
           CoolFeature-Package:
-            config: ios-spm-spm-project-test-config
+            config: ios-spm-project-test-config
 configs:
   ios:
-    ios-spm-spm-project-test-config: |
+    ios-spm-project-test-config: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: ios
@@ -1080,14 +1078,12 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - restore-spm-cache@%s: {}
           - xcode-test@%s:
               inputs:
               - project_path: $BITRISE_PROJECT_PATH
               - scheme: $BITRISE_SCHEME
               - test_repetition_mode: retry_on_failure
               - cache_level: none
-          - save-spm-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -53,6 +53,13 @@ func TestIOS(t *testing.T) {
 			sampleSPMResultYML,
 			sampleSPMVersions,
 		},
+		{
+			"sample-spm-project",
+			"https://github.com/bitrise-io/sample-spm-project.git",
+			"",
+			sampleSPMProjectResultYML,
+			sampleSPMProjectVersions,
+		},
 	}
 
 	helper.Execute(t, testCases)
@@ -1025,3 +1032,65 @@ warnings:
 warnings_with_recommendations:
   ios: []
 `, sampleSPMVersions...)
+
+var sampleSPMProjectVersions = []interface{}{
+	models.FormatVersion,
+
+	// ios-spm-spm-project-test-config/primary
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CacheRestoreSPMVersion,
+	steps.XcodeTestVersion,
+	steps.CacheSaveSPMVersion,
+	steps.DeployToBitriseIoVersion,
+}
+var sampleSPMProjectResultYML = fmt.Sprintf(`options:
+  ios:
+    title: Project or Workspace path
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
+    env_key: BITRISE_PROJECT_PATH
+    type: selector
+    value_map:
+      Package.swift:
+        title: Scheme name
+        summary: An Xcode scheme defines a collection of targets to build, a configuration
+          to use when building, and a collection of tests to execute. Only shared
+          schemes are detected automatically but you can use any scheme as a target
+          on Bitrise. You can change the scheme at any time in your Env Vars.
+        env_key: BITRISE_SCHEME
+        type: selector
+        value_map:
+          CoolFeature-Package:
+            config: ios-spm-spm-project-test-config
+configs:
+  ios:
+    ios-spm-spm-project-test-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: ios
+      workflows:
+        primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - restore-spm-cache@%s: {}
+          - xcode-test@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
+              - cache_level: none
+          - save-spm-cache@%s: {}
+          - deploy-to-bitrise-io@%s: {}
+warnings:
+  ios: []
+warnings_with_recommendations:
+  ios: []
+`, sampleSPMProjectVersions...)

--- a/_tests/integration/mac_test.go
+++ b/_tests/integration/mac_test.go
@@ -43,9 +43,9 @@ var sampleAppsOSX1011Versions = []interface{}{
 var sampleAppsOSX1011ResultYML = fmt.Sprintf(`options:
   macos:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: selector
     value_map:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -357,9 +357,9 @@ var customConfigResultYML = fmt.Sprintf(`options:
             config: default-ionic-config
   ios:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: user_input
     value_map:
@@ -391,9 +391,9 @@ var customConfigResultYML = fmt.Sprintf(`options:
                 config: default-ios-config
   macos:
     title: Project or Workspace path
-    summary: The location of your Xcode project or Xcode workspace files, stored as
-      an Environment Variable. In your Workflows, you can specify paths relative to
-      this path.
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
     env_key: BITRISE_PROJECT_PATH
     type: user_input
     value_map:
@@ -459,9 +459,9 @@ var customConfigResultYML = fmt.Sprintf(`options:
                 value_map:
                   Debug:
                     title: Project or Workspace path
-                    summary: The location of your Xcode project or Xcode workspace
-                      files, stored as an Environment Variable. In your Workflows,
-                      you can specify paths relative to this path.
+                    summary: The location of your Xcode project, Xcode workspace or
+                      SPM project files stored as an Environment Variable. In your
+                      Workflows, you can specify paths relative to this path.
                     env_key: BITRISE_PROJECT_PATH
                     type: user_input
                     value_map:

--- a/_tests/integration/reactnative_test.go
+++ b/_tests/integration/reactnative_test.go
@@ -170,9 +170,9 @@ var sampleAppsReactNativeSubdirResultYML = fmt.Sprintf(`options:
                 value_map:
                   Debug:
                     title: Project or Workspace path
-                    summary: The location of your Xcode project or Xcode workspace
-                      files, stored as an Environment Variable. In your Workflows,
-                      you can specify paths relative to this path.
+                    summary: The location of your Xcode project, Xcode workspace or
+                      SPM project files stored as an Environment Variable. In your
+                      Workflows, you can specify paths relative to this path.
                     env_key: BITRISE_PROJECT_PATH
                     type: selector
                     value_map:
@@ -344,9 +344,9 @@ var sampleAppsReactNativeIosAndAndroidResultYML = fmt.Sprintf(`options:
                 value_map:
                   Debug:
                     title: Project or Workspace path
-                    summary: The location of your Xcode project or Xcode workspace
-                      files, stored as an Environment Variable. In your Workflows,
-                      you can specify paths relative to this path.
+                    summary: The location of your Xcode project, Xcode workspace or
+                      SPM project files stored as an Environment Variable. In your
+                      Workflows, you can specify paths relative to this path.
                     env_key: BITRISE_PROJECT_PATH
                     type: selector
                     value_map:
@@ -516,9 +516,9 @@ var sampleAppsReactNativeIosAndAndroidNoTestResultYML = fmt.Sprintf(`options:
                 value_map:
                   Debug:
                     title: Project or Workspace path
-                    summary: The location of your Xcode project or Xcode workspace
-                      files, stored as an Environment Variable. In your Workflows,
-                      you can specify paths relative to this path.
+                    summary: The location of your Xcode project, Xcode workspace or
+                      SPM project files stored as an Environment Variable. In your
+                      Workflows, you can specify paths relative to this path.
                     env_key: BITRISE_PROJECT_PATH
                     type: selector
                     value_map:
@@ -683,9 +683,9 @@ var sampleAppsReactNativeIosAndAndroidYarnResultYML = fmt.Sprintf(`options:
                 value_map:
                   Debug:
                     title: Project or Workspace path
-                    summary: The location of your Xcode project or Xcode workspace
-                      files, stored as an Environment Variable. In your Workflows,
-                      you can specify paths relative to this path.
+                    summary: The location of your Xcode project, Xcode workspace or
+                      SPM project files stored as an Environment Variable. In your
+                      Workflows, you can specify paths relative to this path.
                     env_key: BITRISE_PROJECT_PATH
                     type: selector
                     value_map:
@@ -856,9 +856,9 @@ var sampleAppsReactNativeJoplinResultYML = fmt.Sprintf(`options:
                 value_map:
                   Debug:
                     title: Project or Workspace path
-                    summary: The location of your Xcode project or Xcode workspace
-                      files, stored as an Environment Variable. In your Workflows,
-                      you can specify paths relative to this path.
+                    summary: The location of your Xcode project, Xcode workspace or
+                      SPM project files stored as an Environment Variable. In your
+                      Workflows, you can specify paths relative to this path.
                     env_key: BITRISE_PROJECT_PATH
                     type: selector
                     value_map:

--- a/scanners/ios/ios.go
+++ b/scanners/ios/ios.go
@@ -35,6 +35,13 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 		return false, err
 	}
 
+	if len(result.Projects) == 0 {
+		result, err = ParseSPMProject(XcodeProjectTypeIOS, searchDir)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	scanner.DetectResult = result
 	detected := len(result.Projects) > 0
 	return detected, nil

--- a/scanners/ios/spmproject.go
+++ b/scanners/ios/spmproject.go
@@ -1,0 +1,137 @@
+package ios
+
+import (
+	"encoding/json"
+	"github.com/bitrise-io/go-utils/command"
+	"os"
+	"path/filepath"
+)
+
+const (
+	spmProjectFile    = "Package.swift"
+	testTargetType    = "test"
+	schemeSuffix      = "-Package"
+	platformNameiOS   = "ios"
+	platformNameMacOS = "macos"
+)
+
+type spmPlatform struct {
+	Name string `json:"platformName"`
+}
+
+type spmProduct struct {
+	Name string `json:"name"`
+}
+
+type spmTarget struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type spmProject struct {
+	Name      string        `json:"name"`
+	Platforms []spmPlatform `json:"platforms"`
+	Products  []spmProduct  `json:"products"`
+	Targets   []spmTarget   `json:"targets"`
+}
+
+func ParseSPMProject(projectType XcodeProjectType, searchDir string) (DetectResult, error) {
+	packagePath := filepath.Join(searchDir, spmProjectFile)
+	if !fileExists(packagePath) {
+		return DetectResult{}, nil
+	}
+
+	cmd := command.New("swift", "package", "dump-package")
+	cmd.SetDir(searchDir)
+	output, err := cmd.RunAndReturnTrimmedOutput()
+	if err != nil {
+		return DetectResult{}, err
+	}
+
+	var proj spmProject
+	err = json.Unmarshal([]byte(output), &proj)
+	if err != nil {
+		return DetectResult{}, err
+	}
+
+	if !supportsProjectType(projectType, proj.Platforms) {
+		return DetectResult{}, nil
+	}
+
+	scheme := Scheme{
+		Name:       schemeName(proj),
+		Missing:    false,
+		HasXCTests: hasTests(proj.Targets),
+		HasAppClip: false,
+		Icons:      nil,
+	}
+	project := Project{
+		RelPath:         spmProjectFile,
+		IsWorkspace:     false,
+		IsPodWorkspace:  false,
+		IsSPMProject:    true,
+		CarthageCommand: "",
+		Warnings:        nil,
+		Schemes:         []Scheme{scheme},
+	}
+	result := DetectResult{
+		Projects:           []Project{project},
+		HasSPMDependencies: true,
+		Warnings:           nil,
+	}
+
+	return result, nil
+}
+
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func supportsProjectType(projectType XcodeProjectType, platforms []spmPlatform) bool {
+	// Developers can either explicitly specify which platforms are supported or leave it empty to indicate that all
+	// the platforms are supported.
+	if len(platforms) == 0 {
+		return true
+	}
+
+	var platformName string
+	if projectType == XcodeProjectTypeIOS {
+		platformName = platformNameiOS
+	} else if projectType == XcodeProjectTypeMacOS {
+		platformName = platformNameMacOS
+	}
+
+	for _, platform := range platforms {
+		if platform.Name == platformName {
+			return true
+		}
+	}
+	return false
+}
+
+func schemeName(project spmProject) string {
+	// SPM has the following behaviour. If there is only a single product defined then the package name will be used as
+	// the scheme name and there will be only one scheme. This scheme will contain all the test targets too.
+	//
+	// But if there are multiple products then every product will have a dedicated scheme with the same name as the
+	// product is called. It will also create an additional scheme which will have the same name as the package plus an
+	// additional `-Package` suffix. Only this package level scheme will contain all the tests and the rest will not.
+	// Based on my testing this is the only valuable scheme which we should be looking for.
+	if len(project.Products) == 1 {
+		return project.Name
+	}
+	return project.Name + schemeSuffix
+}
+
+func hasTests(targets []spmTarget) bool {
+	for _, target := range targets {
+		if target.Type == testTargetType {
+			return true
+		}
+	}
+	return false
+}

--- a/scanners/ios/spmproject.go
+++ b/scanners/ios/spmproject.go
@@ -28,7 +28,7 @@ type spmTarget struct {
 	Type string `json:"type"`
 }
 
-// We do not need the properties because we only the check the dependency existence.
+// We do not need any of the properties because we only check for the existence of the dependencies.
 type spmDependency struct {
 }
 

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -534,7 +534,7 @@ func GenerateOptions(projectType XcodeProjectType, result DetectResult) (models.
 					scheme.HasXCTests,
 					scheme.HasAppClip,
 					result.HasSPMDependencies,
-					project.IsSPMProject,
+					false,
 					exportMethod, scheme.Missing)
 				configDescriptors = append(configDescriptors, configDescriptor)
 				configOption := models.NewConfigOption(configDescriptor.ConfigName(projectType), iconIDs)

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -26,7 +26,7 @@ const (
 	ProjectPathInputKey     = "project_path"
 	ProjectPathInputEnvKey  = "BITRISE_PROJECT_PATH"
 	ProjectPathInputTitle   = "Project or Workspace path"
-	ProjectPathInputSummary = "The location of your Xcode project or Xcode workspace files, stored as an Environment Variable. In your Workflows, you can specify paths relative to this path."
+	ProjectPathInputSummary = "The location of your Xcode project, Xcode workspace or SPM project files stored as an Environment Variable. In your Workflows, you can specify paths relative to this path."
 )
 
 const (
@@ -94,6 +94,7 @@ type Project struct {
 	// Is it a standalone project or a workspace?
 	IsWorkspace    bool
 	IsPodWorkspace bool
+	IsSPMProject   bool
 
 	// Carthage command to run: bootstrap/update
 	CarthageCommand string
@@ -123,17 +124,19 @@ type ConfigDescriptor struct {
 	HasTest              bool
 	HasAppClip           bool
 	HasSPMDependencies   bool
+	isSPMProject         bool
 	ExportMethod         string
 	MissingSharedSchemes bool
 }
 
-func NewConfigDescriptor(hasPodfile bool, carthageCommand string, hasXCTest, hasAppClip, hasSPMDependencies bool, exportMethod string, missingSharedSchemes bool) ConfigDescriptor {
+func NewConfigDescriptor(hasPodfile bool, carthageCommand string, hasXCTest, hasAppClip, hasSPMDependencies, isSPMProject bool, exportMethod string, missingSharedSchemes bool) ConfigDescriptor {
 	return ConfigDescriptor{
 		HasPodfile:           hasPodfile,
 		CarthageCommand:      carthageCommand,
 		HasTest:              hasXCTest,
 		HasAppClip:           hasAppClip,
 		HasSPMDependencies:   hasSPMDependencies,
+		isSPMProject:         isSPMProject,
 		ExportMethod:         exportMethod,
 		MissingSharedSchemes: missingSharedSchemes,
 	}
@@ -149,6 +152,9 @@ func (descriptor ConfigDescriptor) ConfigName(projectType XcodeProjectType) stri
 	}
 	if descriptor.HasSPMDependencies {
 		qualifiers += "-spm"
+	}
+	if descriptor.isSPMProject {
+		qualifiers += "-spm-project"
 	}
 	if descriptor.HasTest {
 		qualifiers += "-test"
@@ -491,6 +497,25 @@ func GenerateOptions(projectType XcodeProjectType, result DetectResult) (models.
 		projectPathOption.AddOption(project.RelPath, schemeOption)
 
 		for _, scheme := range project.Schemes {
+			// SPM projects do not have an icon and do not need the export options.
+			if project.IsSPMProject {
+				configDescriptor := NewConfigDescriptor(
+					project.IsPodWorkspace,
+					project.CarthageCommand,
+					scheme.HasXCTests,
+					scheme.HasAppClip,
+					result.HasSPMDependencies,
+					project.IsSPMProject,
+					"",
+					scheme.Missing)
+				configDescriptors = append(configDescriptors, configDescriptor)
+
+				configOption := models.NewConfigOption(configDescriptor.ConfigName(projectType), []string{})
+				schemeOption.AddOption(scheme.Name, configOption)
+
+				continue
+			}
+
 			exportMethodOption := models.NewOption(exportMethodInputTitle, exportMethodInputSummary, exportMethodEnvKey, models.TypeSelector)
 			schemeOption.AddOption(scheme.Name, exportMethodOption)
 
@@ -503,7 +528,14 @@ func GenerateOptions(projectType XcodeProjectType, result DetectResult) (models.
 
 			for _, exportMethod := range exportMethods {
 				// Whether app-clip export Step is added later depends on the used export method
-				configDescriptor := NewConfigDescriptor(project.IsPodWorkspace, project.CarthageCommand, scheme.HasXCTests, scheme.HasAppClip, result.HasSPMDependencies, exportMethod, scheme.Missing)
+				configDescriptor := NewConfigDescriptor(
+					project.IsPodWorkspace,
+					project.CarthageCommand,
+					scheme.HasXCTests,
+					scheme.HasAppClip,
+					result.HasSPMDependencies,
+					project.IsSPMProject,
+					exportMethod, scheme.Missing)
 				configDescriptors = append(configDescriptors, configDescriptor)
 				configOption := models.NewConfigOption(configDescriptor.ConfigName(projectType), iconIDs)
 
@@ -562,6 +594,7 @@ func GenerateConfigBuilder(
 	hasTest,
 	hasAppClip,
 	hasSPMDependencies,
+	isSPMProject,
 	missingSharedSchemes bool,
 	carthageCommand,
 	exportMethod string,
@@ -582,7 +615,10 @@ func GenerateConfigBuilder(
 	}
 
 	createPrimaryWorkflow(params)
-	createDeployWorkflow(params)
+
+	if !isSPMProject {
+		createDeployWorkflow(params)
+	}
 
 	return *configBuilder
 }
@@ -612,6 +648,7 @@ func GenerateConfig(projectType XcodeProjectType, configDescriptors []ConfigDesc
 			descriptor.HasTest,
 			descriptor.HasAppClip,
 			descriptor.HasSPMDependencies,
+			descriptor.isSPMProject,
 			descriptor.MissingSharedSchemes,
 			descriptor.CarthageCommand,
 			descriptor.ExportMethod)
@@ -640,6 +677,7 @@ func GenerateDefaultConfig(projectType XcodeProjectType) (models.BitriseConfigMa
 		true,
 		false,
 		true,
+		false,
 		true,
 		"",
 		"")

--- a/scanners/ios/utility_test.go
+++ b/scanners/ios/utility_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewConfigDescriptor(t *testing.T) {
-	descriptor := NewConfigDescriptor(false, "", false, false, true, "development", true)
+	descriptor := NewConfigDescriptor(false, "", false, false, true, false, "development", true)
 	require.Equal(t, false, descriptor.HasPodfile)
 	require.Equal(t, false, descriptor.HasTest)
 	require.Equal(t, false, descriptor.HasAppClip)
@@ -28,51 +28,51 @@ func TestConfigName(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			descriptor:         NewConfigDescriptor(false, "", false, false, false, "development", false),
+			descriptor:         NewConfigDescriptor(false, "", false, false, false, false, "development", false),
 			expectedConfigName: "ios-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(true, "", false, false, false, "development", false),
+			descriptor:         NewConfigDescriptor(true, "", false, false, false, false, "development", false),
 			expectedConfigName: "ios-pod-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(false, "", false, false, true, "development", false),
+			descriptor:         NewConfigDescriptor(false, "", false, false, true, false, "development", false),
 			expectedConfigName: "ios-spm-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(false, "bootsrap", false, false, false, "development", false),
+			descriptor:         NewConfigDescriptor(false, "bootsrap", false, false, false, false, "development", false),
 			expectedConfigName: "ios-carthage-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(false, "", true, false, false, "development", false),
+			descriptor:         NewConfigDescriptor(false, "", true, false, false, false, "development", false),
 			expectedConfigName: "ios-test-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(false, "", false, false, false, "development", true),
+			descriptor:         NewConfigDescriptor(false, "", false, false, false, false, "development", true),
 			expectedConfigName: "ios-missing-shared-schemes-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(true, "bootstrap", false, false, false, "development", false),
+			descriptor:         NewConfigDescriptor(true, "bootstrap", false, false, false, false, "development", false),
 			expectedConfigName: "ios-pod-carthage-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(true, "bootstrap", true, false, false, "development", false),
+			descriptor:         NewConfigDescriptor(true, "bootstrap", true, false, false, false, "development", false),
 			expectedConfigName: "ios-pod-carthage-test-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(true, "bootstrap", true, false, false, "development", true),
+			descriptor:         NewConfigDescriptor(true, "bootstrap", true, false, false, false, "development", true),
 			expectedConfigName: "ios-pod-carthage-test-missing-shared-schemes-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(false, "", false, true, false, "development", false),
+			descriptor:         NewConfigDescriptor(false, "", false, true, false, false, "development", false),
 			expectedConfigName: "ios-app-clip-development-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(false, "", false, true, false, "ad-hoc", false),
+			descriptor:         NewConfigDescriptor(false, "", false, true, false, false, "ad-hoc", false),
 			expectedConfigName: "ios-app-clip-ad-hoc-config",
 		},
 		{
-			descriptor:         NewConfigDescriptor(false, "", true, true, false, "development", false),
+			descriptor:         NewConfigDescriptor(false, "", true, true, false, false, "development", false),
 			expectedConfigName: "ios-test-app-clip-development-config",
 		},
 	}

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -71,7 +71,7 @@ func generateIOSOptions(result ios.DetectResult, hasAndroid, hasTests, hasYarnLo
 			schemeOption.AddOption(scheme.Name, exportMethodOption)
 
 			for _, exportMethod := range ios.IosExportMethods {
-				iosConfig := ios.NewConfigDescriptor(project.IsPodWorkspace, project.CarthageCommand, scheme.HasXCTests, scheme.HasAppClip, result.HasSPMDependencies, exportMethod, scheme.Missing)
+				iosConfig := ios.NewConfigDescriptor(project.IsPodWorkspace, project.CarthageCommand, scheme.HasXCTests, scheme.HasAppClip, result.HasSPMDependencies, project.IsSPMProject, exportMethod, scheme.Missing)
 				descriptor := configDescriptor{
 					hasIOS:          true,
 					hasAndroid:      hasAndroid,

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -71,7 +71,15 @@ func generateIOSOptions(result ios.DetectResult, hasAndroid, hasTests, hasYarnLo
 			schemeOption.AddOption(scheme.Name, exportMethodOption)
 
 			for _, exportMethod := range ios.IosExportMethods {
-				iosConfig := ios.NewConfigDescriptor(project.IsPodWorkspace, project.CarthageCommand, scheme.HasXCTests, scheme.HasAppClip, result.HasSPMDependencies, project.IsSPMProject, exportMethod, scheme.Missing)
+				iosConfig := ios.NewConfigDescriptor(
+					project.IsPodWorkspace,
+					project.CarthageCommand,
+					scheme.HasXCTests,
+					scheme.HasAppClip,
+					result.HasSPMDependencies,
+					false,
+					exportMethod,
+					scheme.Missing)
 				descriptor := configDescriptor{
 					hasIOS:          true,
 					hasAndroid:      hasAndroid,


### PR DESCRIPTION
This PR adds pure SPM project support to the iOS scanner. The Mac version will come in a separate PR.

A couple of implementation details:

1.) 
The solution uses the built in swift toolchain to get a json output of the project setup:
```
swift package dump-package
```

2.)
The most common use case of the top SPM projects is to have single product in an SPM project which most of the time is a library product. But you can easily define more than one product in your project. 

Lets take this example:
```
...
let package = Package(
    name: "CoolFeature",
    products: [
        .library(name: "CoolFeature",  targets: ["CoolFeature"]),
    ],
    ...
)
```
When you initialise an empty package with Swift then it sets the package and product name to the same value similar to the example above. In this case Xcode will generate a single scheme called `CoolFeature`.

But in a multi product example:
```
...
let package = Package(
    name: "CoolFeature",
    products: [
        .library(name: "CoolFeature",  targets: ["CoolFeature"]),
        .library(name: "CoolFeature Static", type: .static, targets: ["CoolFeature"]),
        .library(name: "CoolFeatureDynamic", type: .dynamic, targets: ["CoolFeature"]),
    ],
    ...
)
```
Xcode will create four schemes. Three will be for the individual products and one for the package. But it is clear that the package and the first library scheme name will be in conflict as they have the same name. SPM solved this by always automatically appending a `-Package` string to the scheme created from the package name. 

The other interesting fact is that only the scheme created from the package will contains all of the test targets. So the other targets are not that useful than this single main one. So the SPM part of the scanner only looks for this main scheme.

3.)
SPM projects cannot really have a meaningful deploy workflow without user input. There are just a lot of different ways a library can be distributed. So we will not provide a deploy workflow for SPM projects.