### PR TITLE
Apple multiplatform app detection

### DIFF
--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -53,6 +53,13 @@ func TestIOS(t *testing.T) {
 			sampleSPMResultYML,
 			sampleSPMVersions,
 		},
+		{
+			"samples-ios-swiftui-bitrise-todos",
+			"https://github.com/bitrise-io/samples-ios-swiftui-bitrise-todos",
+			"",
+			swiftuiXcode_14_3_ResultYAML,
+			swiftuiXcode_14_3_Versions,
+		},
 	}
 
 	helper.Execute(t, testCases)
@@ -917,6 +924,7 @@ warnings_with_recommendations:
 `, sampleAppClipVersions...)
 
 var sampleSPMVersions = []interface{}{
+	// iOS
 	models.FormatVersion,
 
 	// ios-spm-test-config/deploy
@@ -1025,3 +1033,235 @@ warnings:
 warnings_with_recommendations:
   ios: []
 `, sampleSPMVersions...)
+
+var swiftuiXcode_14_3_Versions = []interface{}{
+	// iOS
+	models.FormatVersion,
+
+	// ios-test-missing-shared-schemes-config/deploy
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.RecreateUserSchemesVersion,
+	steps.XcodeTestVersion,
+	steps.XcodeArchiveVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// ios-test-missing-shared-schemes-config/primary
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.RecreateUserSchemesVersion,
+	steps.XcodeTestVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// macOS
+	models.FormatVersion,
+
+	// ios-test-missing-shared-schemes-config/deploy
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CertificateAndProfileInstallerVersion,
+	steps.RecreateUserSchemesVersion,
+	steps.XcodeTestMacVersion,
+	steps.XcodeArchiveMacVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// ios-test-missing-shared-schemes-config/primary
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.RecreateUserSchemesVersion,
+	steps.XcodeTestMacVersion,
+	steps.DeployToBitriseIoVersion,
+}
+
+var swiftuiXcode_14_3_ResultYAML = fmt.Sprintf(`options:
+  ios:
+    title: Project or Workspace path
+    summary: The location of your Xcode project or Xcode workspace files, stored as
+      an Environment Variable. In your Workflows, you can specify paths relative to
+      this path.
+    env_key: BITRISE_PROJECT_PATH
+    type: selector
+    value_map:
+      Bitrise TODOs Sample.xcodeproj:
+        title: Scheme name
+        summary: An Xcode scheme defines a collection of targets to build, a configuration
+          to use when building, and a collection of tests to execute. Only shared
+          schemes are detected automatically but you can use any scheme as a target
+          on Bitrise. You can change the scheme at any time in your Env Vars.
+        env_key: BITRISE_SCHEME
+        type: selector
+        value_map:
+          Bitrise TODOs Sample:
+            title: Distribution method
+            summary: The export method used to create an .ipa file in your builds,
+              stored as an Environment Variable. You can change this at any time,
+              or even create several .ipa files with different export methods in the
+              same build.
+            env_key: BITRISE_DISTRIBUTION_METHOD
+            type: selector
+            value_map:
+              ad-hoc:
+                config: ios-test-missing-shared-schemes-config
+              app-store:
+                config: ios-test-missing-shared-schemes-config
+              development:
+                config: ios-test-missing-shared-schemes-config
+              enterprise:
+                config: ios-test-missing-shared-schemes-config
+  macos:
+    title: Project or Workspace path
+    summary: The location of your Xcode project or Xcode workspace files, stored as
+      an Environment Variable. In your Workflows, you can specify paths relative to
+      this path.
+    env_key: BITRISE_PROJECT_PATH
+    type: selector
+    value_map:
+      Bitrise TODOs Sample.xcodeproj:
+        title: Scheme name
+        summary: An Xcode scheme defines a collection of targets to build, a configuration
+          to use when building, and a collection of tests to execute. Only shared
+          schemes are detected automatically but you can use any scheme as a target
+          on Bitrise. You can change the scheme at any time in your Env Vars.
+        env_key: BITRISE_SCHEME
+        type: selector
+        value_map:
+          Bitrise TODOs Sample:
+            title: |-
+              Application export method
+              NOTE: `+"`none`"+` means: Export a copy of the application without re-signing.
+            summary: The export method used to create an .app file in your builds,
+              stored as an Environment Variable. You can change this at any time,
+              or even create several .app files with different export methods in the
+              same build.
+            env_key: BITRISE_EXPORT_METHOD
+            type: selector
+            value_map:
+              app-store:
+                config: macos-test-missing-shared-schemes-config
+              developer-id:
+                config: macos-test-missing-shared-schemes-config
+              development:
+                config: macos-test-missing-shared-schemes-config
+              none:
+                config: macos-test-missing-shared-schemes-config
+configs:
+  ios:
+    ios-test-missing-shared-schemes-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: ios
+      workflows:
+        deploy:
+          description: |
+            The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+
+            For testing the *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
+            - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+          - xcode-test@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
+              - cache_level: none
+          - xcode-archive@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - distribution_method: $BITRISE_DISTRIBUTION_METHOD
+              - automatic_code_signing: api-key
+              - cache_level: none
+          - deploy-to-bitrise-io@%s: {}
+        primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+          - xcode-test@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
+              - cache_level: none
+          - deploy-to-bitrise-io@%s: {}
+  macos:
+    macos-test-missing-shared-schemes-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: macos
+      workflows:
+        deploy:
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - certificate-and-profile-installer@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+          - xcode-test-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+          - xcode-archive-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - export_method: $BITRISE_EXPORT_METHOD
+          - deploy-to-bitrise-io@%s: {}
+        primary:
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - recreate-user-schemes@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+          - xcode-test-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+          - deploy-to-bitrise-io@%s: {}
+warnings:
+  ios: []
+  macos: []
+warnings_with_recommendations:
+  ios:
+  - error: |-
+      No shared schemes found for project: Bitrise TODOs Sample.xcodeproj.
+      Automatically generated schemes may differ from the ones in your project.
+      Make sure to <a href="https://support.bitrise.io/hc/en-us/articles/4405779956625">share your schemes</a> for the expected behaviour.
+    recommendations:
+      DetailedError:
+        title: We couldn’t parse your project files.
+        description: |-
+          You can fix the problem and try again, or skip auto-configuration and set up your project manually. Our auto-configurator returned the following error:
+          No shared schemes found for project: Bitrise TODOs Sample.xcodeproj.
+          Automatically generated schemes may differ from the ones in your project.
+          Make sure to <a href="https://support.bitrise.io/hc/en-us/articles/4405779956625">share your schemes</a> for the expected behaviour.
+  macos:
+  - error: |-
+      No shared schemes found for project: Bitrise TODOs Sample.xcodeproj.
+      Automatically generated schemes may differ from the ones in your project.
+      Make sure to <a href="https://support.bitrise.io/hc/en-us/articles/4405779956625">share your schemes</a> for the expected behaviour.
+    recommendations:
+      DetailedError:
+        title: We couldn’t parse your project files.
+        description: |-
+          You can fix the problem and try again, or skip auto-configuration and set up your project manually. Our auto-configurator returned the following error:
+          No shared schemes found for project: Bitrise TODOs Sample.xcodeproj.
+          Automatically generated schemes may differ from the ones in your project.
+          Make sure to <a href="https://support.bitrise.io/hc/en-us/articles/4405779956625">share your schemes</a> for the expected behaviour.`, swiftuiXcode_14_3_Versions...)

--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -57,8 +57,8 @@ func TestIOS(t *testing.T) {
 			"samples-ios-swiftui-bitrise-todos",
 			"https://github.com/bitrise-io/samples-ios-swiftui-bitrise-todos",
 			"",
-			swiftuiXcode_14_3_ResultYAML,
-			swiftuiXcode_14_3_Versions,
+			appleMultiplatformAppResultYAML,
+			appleMultiplatformAppVersions,
 		},
 	}
 
@@ -1034,7 +1034,7 @@ warnings_with_recommendations:
   ios: []
 `, sampleSPMVersions...)
 
-var swiftuiXcode_14_3_Versions = []interface{}{
+var appleMultiplatformAppVersions = []interface{}{
 	// iOS
 	models.FormatVersion,
 
@@ -1073,7 +1073,7 @@ var swiftuiXcode_14_3_Versions = []interface{}{
 	steps.DeployToBitriseIoVersion,
 }
 
-var swiftuiXcode_14_3_ResultYAML = fmt.Sprintf(`options:
+var appleMultiplatformAppResultYAML = fmt.Sprintf(`options:
   ios:
     title: Project or Workspace path
     summary: The location of your Xcode project or Xcode workspace files, stored as
@@ -1264,4 +1264,4 @@ warnings_with_recommendations:
           You can fix the problem and try again, or skip auto-configuration and set up your project manually. Our auto-configurator returned the following error:
           No shared schemes found for project: Bitrise TODOs Sample.xcodeproj.
           Automatically generated schemes may differ from the ones in your project.
-          Make sure to <a href="https://support.bitrise.io/hc/en-us/articles/4405779956625">share your schemes</a> for the expected behaviour.`, swiftuiXcode_14_3_Versions...)
+          Make sure to <a href="https://support.bitrise.io/hc/en-us/articles/4405779956625">share your schemes</a> for the expected behaviour.`, appleMultiplatformAppVersions...)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18
-	github.com/bitrise-io/go-xcode v1.0.12-0.20230705122633-799e92a217ef
+	github.com/bitrise-io/go-xcode v1.0.12-0.20230705123505-38b276ab964f
 	github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1
 	github.com/bitrise-io/stepman v0.0.0-20210517135458-203f7a48d37a
 	github.com/google/go-cmp v0.5.6

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18
-	github.com/bitrise-io/go-xcode v1.0.6
+	github.com/bitrise-io/go-xcode v1.0.12-0.20230705122633-799e92a217ef
 	github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1
 	github.com/bitrise-io/stepman v0.0.0-20210517135458-203f7a48d37a
 	github.com/google/go-cmp v0.5.6

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18
-	github.com/bitrise-io/go-xcode v1.0.12-0.20230705123505-38b276ab964f
+	github.com/bitrise-io/go-xcode v1.0.12
 	github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1
 	github.com/bitrise-io/stepman v0.0.0-20210517135458-203f7a48d37a
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/bitrise-io/go-utils v1.0.1 h1:e7mepVBkVN1DXRPESNXb0djEw6bxB6B93p/Q74z
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18 h1:+JEzJ3N4FWxnMS9n6RiBEc9s5w4ZR8NW1Tz061mhn3g=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
-github.com/bitrise-io/go-xcode v1.0.6 h1:hSKwkDXUn9/gMk6HiJRUvurGWelfQEBWcO7JAvXi+y8=
-github.com/bitrise-io/go-xcode v1.0.6/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.12-0.20230705122633-799e92a217ef h1:yZrCSuJGEaMJGaEGDCY4CwJYGtEdXLSupLJRGTioAPs=
+github.com/bitrise-io/go-xcode v1.0.12-0.20230705122633-799e92a217ef/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1 h1:iQZl/dKHp14xol7ye4e9FaSrw8o27TF5/nv3aUDfdD0=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
 github.com/bitrise-io/gows v0.0.0-20210505125306-dd92ff463938/go.mod h1:3Cp9ceJ8wHl1Av6oEE2ff1iWaYLliQuD+oaNdyM0NWQ=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/bitrise-io/go-utils v1.0.1 h1:e7mepVBkVN1DXRPESNXb0djEw6bxB6B93p/Q74z
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18 h1:+JEzJ3N4FWxnMS9n6RiBEc9s5w4ZR8NW1Tz061mhn3g=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
-github.com/bitrise-io/go-xcode v1.0.12-0.20230705122633-799e92a217ef h1:yZrCSuJGEaMJGaEGDCY4CwJYGtEdXLSupLJRGTioAPs=
-github.com/bitrise-io/go-xcode v1.0.12-0.20230705122633-799e92a217ef/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.12-0.20230705123505-38b276ab964f h1:JjscxRDOJbpM31ChzpDk/rEdlueUqs2Ihaa18Lqj+5U=
+github.com/bitrise-io/go-xcode v1.0.12-0.20230705123505-38b276ab964f/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1 h1:iQZl/dKHp14xol7ye4e9FaSrw8o27TF5/nv3aUDfdD0=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
 github.com/bitrise-io/gows v0.0.0-20210505125306-dd92ff463938/go.mod h1:3Cp9ceJ8wHl1Av6oEE2ff1iWaYLliQuD+oaNdyM0NWQ=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/bitrise-io/go-utils v1.0.1 h1:e7mepVBkVN1DXRPESNXb0djEw6bxB6B93p/Q74z
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18 h1:+JEzJ3N4FWxnMS9n6RiBEc9s5w4ZR8NW1Tz061mhn3g=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.18/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
-github.com/bitrise-io/go-xcode v1.0.12-0.20230705123505-38b276ab964f h1:JjscxRDOJbpM31ChzpDk/rEdlueUqs2Ihaa18Lqj+5U=
-github.com/bitrise-io/go-xcode v1.0.12-0.20230705123505-38b276ab964f/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.12 h1:r8hziEOr6mV6XLWv8ZXZ4hgGyNEG+JzdU/68A+Ws42g=
+github.com/bitrise-io/go-xcode v1.0.12/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1 h1:iQZl/dKHp14xol7ye4e9FaSrw8o27TF5/nv3aUDfdD0=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
 github.com/bitrise-io/gows v0.0.0-20210505125306-dd92ff463938/go.mod h1:3Cp9ceJ8wHl1Av6oEE2ff1iWaYLliQuD+oaNdyM0NWQ=

--- a/vendor/github.com/bitrise-io/go-xcode/pathfilters/pathfilters.go
+++ b/vendor/github.com/bitrise-io/go-xcode/pathfilters/pathfilters.go
@@ -74,7 +74,7 @@ var AllowIphoneosSDKFilter = SDKFilter("iphoneos", true)
 var AllowMacosxSDKFilter = SDKFilter("macosx", true)
 
 // SDKFilter ...
-func SDKFilter(sdk string, allowed bool) pathutil.FilterFunc {
+func SDKFilter(expectedSDK string, allowed bool) pathutil.FilterFunc {
 	return func(pth string) (bool, error) {
 		found := false
 
@@ -127,6 +127,10 @@ func SDKFilter(sdk string, allowed bool) pathutil.FilterFunc {
 					sdkMap[sdk] = true
 				}
 
+				if sdk != "auto" {
+					continue
+				}
+
 				supportedPlatformsValue, err := buildConfiguration.BuildSettings.String("SUPPORTED_PLATFORMS")
 				if err == nil {
 					supportedPlatforms := strings.Split(supportedPlatformsValue, " ")
@@ -137,14 +141,14 @@ func SDKFilter(sdk string, allowed bool) pathutil.FilterFunc {
 			}
 
 			for projectSDK := range sdkMap {
-				if projectSDK == sdk {
+				if projectSDK == expectedSDK {
 					found = true
 					break
 				}
 			}
 
 			for platform := range supportedPlatformsMap {
-				if platform == sdk {
+				if platform == expectedSDK {
 					found = true
 					break
 				}

--- a/vendor/github.com/bitrise-io/go-xcode/pathfilters/pathfilters.go
+++ b/vendor/github.com/bitrise-io/go-xcode/pathfilters/pathfilters.go
@@ -2,6 +2,7 @@ package pathfilters
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj"
@@ -126,8 +127,9 @@ func SDKFilter(sdk string, allowed bool) pathutil.FilterFunc {
 					sdkMap[sdk] = true
 				}
 
-				supportedPlatforms, err := buildConfiguration.BuildSettings.StringSlice("SUPPORTED_PLATFORMS")
+				supportedPlatformsValue, err := buildConfiguration.BuildSettings.String("SUPPORTED_PLATFORMS")
 				if err == nil {
+					supportedPlatforms := strings.Split(supportedPlatformsValue, " ")
 					for _, platform := range supportedPlatforms {
 						supportedPlatformsMap[platform] = true
 					}

--- a/vendor/github.com/bitrise-io/go-xcode/pathfilters/pathfilters_testdata.go
+++ b/vendor/github.com/bitrise-io/go-xcode/pathfilters/pathfilters_testdata.go
@@ -1,5 +1,629 @@
 package pathfilters
 
+const testMultiplatformPbxprojContent = `// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BA734C172A5191D700D84300 /* TasksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA734C162A5191D700D84300 /* TasksTests.swift */; };
+		BAC4978C2A4A0B1400069402 /* Bitrise_TODOs_SampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC4978B2A4A0B1400069402 /* Bitrise_TODOs_SampleApp.swift */; };
+		BAC4978E2A4A0B1400069402 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC4978D2A4A0B1400069402 /* ContentView.swift */; };
+		BAC497902A4A0B1400069402 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAC4978F2A4A0B1400069402 /* Assets.xcassets */; };
+		BAC497942A4A0B1400069402 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAC497932A4A0B1400069402 /* Preview Assets.xcassets */; };
+		BAC4979E2A4A0B1400069402 /* Bitrise_TODOs_SampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC4979D2A4A0B1400069402 /* Bitrise_TODOs_SampleTests.swift */; };
+		BAC497A82A4A0B1400069402 /* Bitrise_TODOs_SampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC497A72A4A0B1400069402 /* Bitrise_TODOs_SampleUITests.swift */; };
+		BAC497AA2A4A0B1400069402 /* Bitrise_TODOs_SampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC497A92A4A0B1400069402 /* Bitrise_TODOs_SampleUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		BAC4979A2A4A0B1400069402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BAC497802A4A0B1300069402 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BAC497872A4A0B1400069402;
+			remoteInfo = "Bitrise TODOs Sample";
+		};
+		BAC497A42A4A0B1400069402 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BAC497802A4A0B1300069402 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BAC497872A4A0B1400069402;
+			remoteInfo = "Bitrise TODOs Sample";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		BA734C162A5191D700D84300 /* TasksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksTests.swift; sourceTree = "<group>"; };
+		BAC497882A4A0B1400069402 /* Bitrise TODOs Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Bitrise TODOs Sample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BAC4978B2A4A0B1400069402 /* Bitrise_TODOs_SampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bitrise_TODOs_SampleApp.swift; sourceTree = "<group>"; };
+		BAC4978D2A4A0B1400069402 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BAC4978F2A4A0B1400069402 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		BAC497912A4A0B1400069402 /* Bitrise_TODOs_Sample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Bitrise_TODOs_Sample.entitlements; sourceTree = "<group>"; };
+		BAC497932A4A0B1400069402 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		BAC497992A4A0B1400069402 /* Bitrise TODOs SampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Bitrise TODOs SampleTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BAC4979D2A4A0B1400069402 /* Bitrise_TODOs_SampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bitrise_TODOs_SampleTests.swift; sourceTree = "<group>"; };
+		BAC497A32A4A0B1400069402 /* Bitrise TODOs SampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Bitrise TODOs SampleUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BAC497A72A4A0B1400069402 /* Bitrise_TODOs_SampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bitrise_TODOs_SampleUITests.swift; sourceTree = "<group>"; };
+		BAC497A92A4A0B1400069402 /* Bitrise_TODOs_SampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bitrise_TODOs_SampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BAC497852A4A0B1400069402 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BAC497962A4A0B1400069402 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BAC497A02A4A0B1400069402 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BAC4977F2A4A0B1300069402 = {
+			isa = PBXGroup;
+			children = (
+				BAC4978A2A4A0B1400069402 /* Bitrise TODOs Sample */,
+				BAC4979C2A4A0B1400069402 /* Bitrise TODOs SampleTests */,
+				BAC497A62A4A0B1400069402 /* Bitrise TODOs SampleUITests */,
+				BAC497892A4A0B1400069402 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BAC497892A4A0B1400069402 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BAC497882A4A0B1400069402 /* Bitrise TODOs Sample.app */,
+				BAC497992A4A0B1400069402 /* Bitrise TODOs SampleTests.xctest */,
+				BAC497A32A4A0B1400069402 /* Bitrise TODOs SampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BAC4978A2A4A0B1400069402 /* Bitrise TODOs Sample */ = {
+			isa = PBXGroup;
+			children = (
+				BAC4978B2A4A0B1400069402 /* Bitrise_TODOs_SampleApp.swift */,
+				BAC4978D2A4A0B1400069402 /* ContentView.swift */,
+				BAC4978F2A4A0B1400069402 /* Assets.xcassets */,
+				BAC497912A4A0B1400069402 /* Bitrise_TODOs_Sample.entitlements */,
+				BAC497922A4A0B1400069402 /* Preview Content */,
+			);
+			path = "Bitrise TODOs Sample";
+			sourceTree = "<group>";
+		};
+		BAC497922A4A0B1400069402 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				BAC497932A4A0B1400069402 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		BAC4979C2A4A0B1400069402 /* Bitrise TODOs SampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				BAC4979D2A4A0B1400069402 /* Bitrise_TODOs_SampleTests.swift */,
+				BA734C162A5191D700D84300 /* TasksTests.swift */,
+			);
+			path = "Bitrise TODOs SampleTests";
+			sourceTree = "<group>";
+		};
+		BAC497A62A4A0B1400069402 /* Bitrise TODOs SampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				BAC497A72A4A0B1400069402 /* Bitrise_TODOs_SampleUITests.swift */,
+				BAC497A92A4A0B1400069402 /* Bitrise_TODOs_SampleUITestsLaunchTests.swift */,
+			);
+			path = "Bitrise TODOs SampleUITests";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		BAC497872A4A0B1400069402 /* Bitrise TODOs Sample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BAC497AD2A4A0B1400069402 /* Build configuration list for PBXNativeTarget "Bitrise TODOs Sample" */;
+			buildPhases = (
+				BAC497842A4A0B1400069402 /* Sources */,
+				BAC497852A4A0B1400069402 /* Frameworks */,
+				BAC497862A4A0B1400069402 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Bitrise TODOs Sample";
+			productName = "Bitrise TODOs Sample";
+			productReference = BAC497882A4A0B1400069402 /* Bitrise TODOs Sample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		BAC497982A4A0B1400069402 /* Bitrise TODOs SampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BAC497B02A4A0B1400069402 /* Build configuration list for PBXNativeTarget "Bitrise TODOs SampleTests" */;
+			buildPhases = (
+				BAC497952A4A0B1400069402 /* Sources */,
+				BAC497962A4A0B1400069402 /* Frameworks */,
+				BAC497972A4A0B1400069402 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BAC4979B2A4A0B1400069402 /* PBXTargetDependency */,
+			);
+			name = "Bitrise TODOs SampleTests";
+			productName = "Bitrise TODOs SampleTests";
+			productReference = BAC497992A4A0B1400069402 /* Bitrise TODOs SampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		BAC497A22A4A0B1400069402 /* Bitrise TODOs SampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BAC497B32A4A0B1400069402 /* Build configuration list for PBXNativeTarget "Bitrise TODOs SampleUITests" */;
+			buildPhases = (
+				BAC4979F2A4A0B1400069402 /* Sources */,
+				BAC497A02A4A0B1400069402 /* Frameworks */,
+				BAC497A12A4A0B1400069402 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BAC497A52A4A0B1400069402 /* PBXTargetDependency */,
+			);
+			name = "Bitrise TODOs SampleUITests";
+			productName = "Bitrise TODOs SampleUITests";
+			productReference = BAC497A32A4A0B1400069402 /* Bitrise TODOs SampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BAC497802A4A0B1300069402 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1430;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					BAC497872A4A0B1400069402 = {
+						CreatedOnToolsVersion = 14.3;
+					};
+					BAC497982A4A0B1400069402 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = BAC497872A4A0B1400069402;
+					};
+					BAC497A22A4A0B1400069402 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = BAC497872A4A0B1400069402;
+					};
+				};
+			};
+			buildConfigurationList = BAC497832A4A0B1400069402 /* Build configuration list for PBXProject "Bitrise TODOs Sample" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = BAC4977F2A4A0B1300069402;
+			productRefGroup = BAC497892A4A0B1400069402 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BAC497872A4A0B1400069402 /* Bitrise TODOs Sample */,
+				BAC497982A4A0B1400069402 /* Bitrise TODOs SampleTests */,
+				BAC497A22A4A0B1400069402 /* Bitrise TODOs SampleUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BAC497862A4A0B1400069402 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BAC497942A4A0B1400069402 /* Preview Assets.xcassets in Resources */,
+				BAC497902A4A0B1400069402 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BAC497972A4A0B1400069402 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BAC497A12A4A0B1400069402 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BAC497842A4A0B1400069402 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BAC4978E2A4A0B1400069402 /* ContentView.swift in Sources */,
+				BAC4978C2A4A0B1400069402 /* Bitrise_TODOs_SampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BAC497952A4A0B1400069402 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BA734C172A5191D700D84300 /* TasksTests.swift in Sources */,
+				BAC4979E2A4A0B1400069402 /* Bitrise_TODOs_SampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BAC4979F2A4A0B1400069402 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BAC497A82A4A0B1400069402 /* Bitrise_TODOs_SampleUITests.swift in Sources */,
+				BAC497AA2A4A0B1400069402 /* Bitrise_TODOs_SampleUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		BAC4979B2A4A0B1400069402 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BAC497872A4A0B1400069402 /* Bitrise TODOs Sample */;
+			targetProxy = BAC4979A2A4A0B1400069402 /* PBXContainerItemProxy */;
+		};
+		BAC497A52A4A0B1400069402 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BAC497872A4A0B1400069402 /* Bitrise TODOs Sample */;
+			targetProxy = BAC497A42A4A0B1400069402 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		BAC497AB2A4A0B1400069402 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		BAC497AC2A4A0B1400069402 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		BAC497AE2A4A0B1400069402 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Bitrise TODOs Sample/Bitrise_TODOs_Sample.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Bitrise TODOs Sample/Preview Content\"";
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.Bitrise-TODOs-Sample";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BAC497AF2A4A0B1400069402 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Bitrise TODOs Sample/Bitrise_TODOs_Sample.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Bitrise TODOs Sample/Preview Content\"";
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.Bitrise-TODOs-Sample";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		BAC497B12A4A0B1400069402 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.Bitrise-TODOs-SampleTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Bitrise TODOs Sample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Bitrise TODOs Sample";
+			};
+			name = Debug;
+		};
+		BAC497B22A4A0B1400069402 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.Bitrise-TODOs-SampleTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Bitrise TODOs Sample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Bitrise TODOs Sample";
+			};
+			name = Release;
+		};
+		BAC497B42A4A0B1400069402 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.Bitrise-TODOs-SampleUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Bitrise TODOs Sample";
+			};
+			name = Debug;
+		};
+		BAC497B52A4A0B1400069402 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.Bitrise-TODOs-SampleUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Bitrise TODOs Sample";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BAC497832A4A0B1400069402 /* Build configuration list for PBXProject "Bitrise TODOs Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BAC497AB2A4A0B1400069402 /* Debug */,
+				BAC497AC2A4A0B1400069402 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BAC497AD2A4A0B1400069402 /* Build configuration list for PBXNativeTarget "Bitrise TODOs Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BAC497AE2A4A0B1400069402 /* Debug */,
+				BAC497AF2A4A0B1400069402 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BAC497B02A4A0B1400069402 /* Build configuration list for PBXNativeTarget "Bitrise TODOs SampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BAC497B12A4A0B1400069402 /* Debug */,
+				BAC497B22A4A0B1400069402 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BAC497B32A4A0B1400069402 /* Build configuration list for PBXNativeTarget "Bitrise TODOs SampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BAC497B42A4A0B1400069402 /* Debug */,
+				BAC497B52A4A0B1400069402 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BAC497802A4A0B1300069402 /* Project object */;
+}
+
+`
+
 const testMacOSPbxprojContent = `// !$*UTF8*$!
 {
 	archiveVersion = 1;

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -3,7 +3,6 @@ package xcodebuild
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
@@ -68,12 +67,9 @@ func (m *ResolvePackagesCommandModel) command() command.Model {
 
 // Run runs the command and logs elapsed time
 func (m *ResolvePackagesCommandModel) Run() error {
-	var (
-		cmd   = m.command()
-		start = time.Now()
-	)
+	var cmd = m.command()
 
-	log.Printf("Resolving package dependencies...")
+	log.TPrintf("Resolving package dependencies...")
 
 	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	if err := cmd.Run(); err != nil {
@@ -83,7 +79,7 @@ func (m *ResolvePackagesCommandModel) Run() error {
 		return fmt.Errorf("failed to run command: %s", err)
 	}
 
-	log.Printf("Resolved package dependencies in %s.", time.Since(start).Round(time.Second))
+	log.TPrintf("Resolved package dependencies.")
 
 	return nil
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
@@ -119,12 +118,9 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
-	var (
-		cmd   = c.Command()
-		start = time.Now()
-	)
+	var cmd = c.Command()
 
-	log.Printf("Reading build settings...")
+	log.TPrintf("Reading build settings...")
 
 	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
@@ -135,7 +131,7 @@ func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object
 		return nil, fmt.Errorf("failed to run command %s: %s", cmd.PrintableCommandArgs(), err)
 	}
 
-	log.Printf("Read target settings in %s.", time.Since(start).Round(time.Second))
+	log.TPrintf("Read target settings.")
 
 	return parseBuildSettings(out)
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/proj.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/proj.go
@@ -3,6 +3,7 @@ package xcodeproj
 import (
 	"fmt"
 
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
 )
 
@@ -15,6 +16,8 @@ type Proj struct {
 }
 
 func parseProj(id string, objects serialized.Object) (Proj, error) {
+	log.TDebugf("Parsing xcode project file with id: %s", id)
+
 	rawPBXProj, err := objects.Object(id)
 	if err != nil {
 		return Proj{}, fmt.Errorf("failed to access object with id %s: %s", id, err)
@@ -58,6 +61,8 @@ func parseProj(id string, objects serialized.Object) (Proj, error) {
 		}
 		targets = append(targets, target)
 	}
+
+	log.TDebugf("Parsed xcode project file with id: %s, found %v targets.", id, len(targets))
 
 	return Proj{
 		ID:                     id,

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/recreate_schemes.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/recreate_schemes.go
@@ -44,6 +44,8 @@ func (p XcodeProj) SaveSharedScheme(scheme xcscheme.Scheme) error {
 
 // ReCreateSchemes creates new schemes based on the available Targets
 func (p XcodeProj) ReCreateSchemes() []xcscheme.Scheme {
+	fmt.Printf("Recreating xcode scheme")
+
 	var schemes []xcscheme.Scheme
 	for _, buildTarget := range p.Proj.Targets {
 		if buildTarget.Type != NativeTargetType || buildTarget.IsTest() {
@@ -59,6 +61,8 @@ func (p XcodeProj) ReCreateSchemes() []xcscheme.Scheme {
 
 		schemes = append(schemes, newScheme(buildTarget, testTargets, filepath.Base(p.Path)))
 	}
+
+	fmt.Printf("Recreated %v xcode schemes", len(schemes))
 
 	return schemes
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
 )
 
@@ -117,10 +118,14 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 		return Target{}, err
 	}
 
+	log.TDebugf("Parsing build configuration list for target: %s", id)
+
 	buildConfigurationList, err := parseConfigurationList(buildConfigurationListID, objects)
 	if err != nil {
 		return Target{}, err
 	}
+
+	log.TDebugf("Parsed build configuration list")
 
 	dependencyIDs, err := rawTarget.StringSlice("dependencies")
 	if err != nil {
@@ -128,6 +133,9 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 	}
 
 	var dependencies []TargetDependency
+
+	log.TDebugf("Parsing all target dependencies for target: %s", id)
+
 	for _, dependencyID := range dependencyIDs {
 		dependency, err := parseTargetDependency(dependencyID, objects)
 		if err != nil {
@@ -142,6 +150,8 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 
 		dependencies = append(dependencies, dependency)
 	}
+
+	log.TDebugf("Parsed %v target dependencies", len(dependencies))
 
 	var productReference ProductReference
 	productReferenceID, err := rawTarget.String("productReference")

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/xcodeproj.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/xcodeproj.go
@@ -110,6 +110,9 @@ func (p XcodeProj) TargetInfoplistPath(target, configuration string) (string, er
 // The returned list contains each target only once, using the target ID for uniqueness.
 func (p XcodeProj) DependentTargetsOfTarget(target Target) []Target {
 	var dependentTargets []Target
+
+	log.TDebugf("Locating all dependencies of target: %s", target.Name)
+
 	for _, dependency := range target.Dependencies {
 		childTarget, ok := p.Proj.Target(dependency.TargetID)
 		if !ok {
@@ -121,6 +124,8 @@ func (p XcodeProj) DependentTargetsOfTarget(target Target) []Target {
 		childDependentTargets := p.DependentTargetsOfTarget(childTarget)
 		dependentTargets = append(dependentTargets, childDependentTargets...)
 	}
+
+	log.TDebugf("Located %v dependencies of target: %s", len(dependentTargets), target.Name)
 
 	return deduplicateTargetList(dependentTargets)
 }
@@ -344,7 +349,13 @@ func (p XcodeProj) Scheme(name string) (*xcscheme.Scheme, string, error) {
 
 // Schemes ...
 func (p XcodeProj) Schemes() ([]xcscheme.Scheme, error) {
-	return xcscheme.FindSchemesIn(p.Path)
+	log.TDebugf("Locating scheme for project path: %s", p.Path)
+
+	schemes, err := xcscheme.FindSchemesIn(p.Path)
+
+	log.TDebugf("Located %v schemes", len(schemes))
+
+	return schemes, err
 }
 
 // Open ...
@@ -368,6 +379,8 @@ func Open(pth string) (XcodeProj, error) {
 
 	p.Path = absPth
 	p.Name = strings.TrimSuffix(filepath.Base(absPth), filepath.Ext(absPth))
+
+	log.TDebugf("Opened xcode project")
 
 	return *p, nil
 }
@@ -540,7 +553,13 @@ func writeAttributeForAllSDKs(buildSettings serialized.Object, newKey string, ne
 //
 // Overrides the project.pbxproj file of the XcodeProj with the contents of `rawProj`
 func (p XcodeProj) Save() error {
-	return p.savePBXProj()
+	log.Debugf("Saving PBX file")
+
+	err := p.savePBXProj()
+
+	log.Debugf("Saved PBX file")
+
+	return err
 }
 
 // savePBXProj overrides the project.pbxproj file of  the XcodeProj with the contents of `rawProj`
@@ -739,6 +758,8 @@ func deduplicateTargetList(targets []Target) []Target {
 			uniqueTargets = append(uniqueTargets, target)
 		}
 	}
+
+	log.Debugf("Deduplicating targets result: %v/%v", len(targets), len(uniqueTargets))
 
 	return uniqueTargets
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcscheme/xcscheme.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcscheme/xcscheme.go
@@ -3,11 +3,14 @@ package xcscheme
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
-	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
@@ -70,6 +73,25 @@ func (r TestableReference) isTestable() bool {
 	return r.Skipped == "NO" && r.BuildableReference.isTestProduct()
 }
 
+// TestPlanReference ...
+type TestPlanReference struct {
+	Reference string `xml:"reference,attr,omitempty"`
+	Default   string `xml:"default,attr,omitempty"`
+}
+
+// IsDefault ...
+func (r TestPlanReference) IsDefault() bool {
+	return r.Default == "YES"
+}
+
+// Name ...
+func (r TestPlanReference) Name() string {
+	// reference = "container:FullTests.xctestplan"
+	idx := strings.Index(r.Reference, ":")
+	testPlanFileName := r.Reference[idx+1:]
+	return strings.TrimSuffix(testPlanFileName, filepath.Ext(testPlanFileName))
+}
+
 // MacroExpansion ...
 type MacroExpansion struct {
 	BuildableReference BuildableReference
@@ -77,6 +99,11 @@ type MacroExpansion struct {
 
 // AdditionalOptions ...
 type AdditionalOptions struct {
+}
+
+// TestPlans ...
+type TestPlans struct {
+	TestPlanReferences []TestPlanReference `xml:"TestPlanReference,omitempty"`
 }
 
 // TestAction ...
@@ -87,6 +114,7 @@ type TestAction struct {
 	ShouldUseLaunchSchemeArgsEnv string `xml:"shouldUseLaunchSchemeArgsEnv,attr"`
 
 	Testables         []TestableReference `xml:"Testables>TestableReference"`
+	TestPlans         *TestPlans
 	MacroExpansion    MacroExpansion
 	AdditionalOptions AdditionalOptions
 }
@@ -154,20 +182,34 @@ type Scheme struct {
 
 // Open ...
 func Open(pth string) (Scheme, error) {
-	b, err := fileutil.ReadBytesFromFile(pth)
+	var start = time.Now()
+
+	f, err := os.Open(pth)
 	if err != nil {
 		return Scheme{}, err
 	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Warnf("Failed to close scheme: %s: %s", pth, err)
+		}
+	}()
 
-	var scheme Scheme
-	if err := xml.Unmarshal(b, &scheme); err != nil {
-		return Scheme{}, fmt.Errorf("failed to unmarshal scheme file: %s, error: %s", pth, err)
+	scheme, err := parse(f)
+	if err != nil {
+		return Scheme{}, fmt.Errorf("failed to unmarshal scheme file: %s: %s", pth, err)
 	}
 
 	scheme.Name = strings.TrimSuffix(filepath.Base(pth), filepath.Ext(pth))
 	scheme.Path = pth
 
+	log.Printf("Read %s scheme in %s.", scheme.Name, time.Since(start).Round(time.Second))
+
 	return scheme, nil
+}
+
+func parse(reader io.Reader) (scheme Scheme, err error) {
+	err = xml.NewDecoder(reader).Decode(&scheme)
+	return
 }
 
 // XMLToken ...
@@ -248,4 +290,20 @@ func (s Scheme) IsTestable() bool {
 	}
 
 	return false
+}
+
+// DefaultTestPlan ...
+func (s Scheme) DefaultTestPlan() *TestPlanReference {
+	if s.TestAction.TestPlans == nil {
+		return nil
+	}
+
+	testPlans := *s.TestAction.TestPlans
+
+	for _, testPlanRef := range testPlans.TestPlanReferences {
+		if testPlanRef.IsDefault() {
+			return &testPlanRef
+		}
+	}
+	return nil
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace/xcworkspace.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace/xcworkspace.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-xcode/xcodebuild"
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
@@ -50,15 +51,24 @@ func (w Workspace) Scheme(name string) (*xcscheme.Scheme, string, error) {
 
 // SchemeBuildSettings ...
 func (w Workspace) SchemeBuildSettings(scheme, configuration string, customOptions ...string) (serialized.Object, error) {
+	log.TDebugf("Fetching %s scheme build settings", scheme)
+
 	commandModel := xcodebuild.NewShowBuildSettingsCommand(w.Path)
 	commandModel.SetScheme(scheme)
 	commandModel.SetConfiguration(configuration)
 	commandModel.SetCustomOptions(customOptions)
-	return commandModel.RunAndReturnSettings()
+
+	object, err := commandModel.RunAndReturnSettings()
+
+	log.TDebugf("Fetched %s scheme build settings", scheme)
+
+	return object, err
 }
 
 // Schemes ...
 func (w Workspace) Schemes() (map[string][]xcscheme.Scheme, error) {
+	log.TDebugf("Looking for schemes in workspace: %s", w.Name)
+
 	schemesByContainer := map[string][]xcscheme.Scheme{}
 
 	workspaceSchemes, err := xcscheme.FindSchemesIn(w.Path)
@@ -94,6 +104,8 @@ func (w Workspace) Schemes() (map[string][]xcscheme.Scheme, error) {
 
 		schemesByContainer[project.Path] = projectSchemes
 	}
+
+	log.TDebugf("Found %v workspace schemes", len(schemesByContainer))
 
 	return schemesByContainer, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,7 +38,7 @@ github.com/bitrise-io/go-utils/sliceutil
 ## explicit; go 1.17
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.6
+# github.com/bitrise-io/go-xcode v1.0.12-0.20230705122633-799e92a217ef
 ## explicit; go 1.15
 github.com/bitrise-io/go-xcode/pathfilters
 github.com/bitrise-io/go-xcode/xcodebuild

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,7 +38,7 @@ github.com/bitrise-io/go-utils/sliceutil
 ## explicit; go 1.17
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.12-0.20230705122633-799e92a217ef
+# github.com/bitrise-io/go-xcode v1.0.12-0.20230705123505-38b276ab964f
 ## explicit; go 1.15
 github.com/bitrise-io/go-xcode/pathfilters
 github.com/bitrise-io/go-xcode/xcodebuild

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,7 +38,7 @@ github.com/bitrise-io/go-utils/sliceutil
 ## explicit; go 1.17
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.12-0.20230705123505-38b276ab964f
+# github.com/bitrise-io/go-xcode v1.0.12
 ## explicit; go 1.15
 github.com/bitrise-io/go-xcode/pathfilters
 github.com/bitrise-io/go-xcode/xcodebuild


### PR DESCRIPTION
### Context

This PR adds support for Apple Multiplatform App projects.

More info here: https://github.com/bitrise-io/go-xcode/pull/198

JIRA ticket: https://bitrise.atlassian.net/browse/BIVS-1998

### Changes

- Pull the latest go-xcode version
- Test Apple Multiplatform App projects

### Decisions

For the sake of simplicity, I just pulled the new go-xcode platform detection logic, this means in the case of an Apple Multiplatform App project, both the iOS and macOS scanner detects the project. The user needs to select either iOS or macOS project type and the config will contain related workflows.

An alternative or future improvement would be providing workflows to test and build both platforms.