### PR TITLE
[CI-1813] Mac spm project detection

### DIFF
--- a/_tests/integration/ios_test.go
+++ b/_tests/integration/ios_test.go
@@ -1282,6 +1282,15 @@ var sampleSPMProjectVersions = []interface{}{
 	steps.GitCloneVersion,
 	steps.XcodeTestVersion,
 	steps.DeployToBitriseIoVersion,
+
+	// macOS
+	models.FormatVersion,
+
+	// macos-spm-project-test-config
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.XcodeTestMacVersion,
+	steps.DeployToBitriseIoVersion,
 }
 var sampleSPMProjectResultYML = fmt.Sprintf(`options:
   ios:
@@ -1303,6 +1312,25 @@ var sampleSPMProjectResultYML = fmt.Sprintf(`options:
         value_map:
           CoolFeature-Package:
             config: ios-spm-project-test-config
+  macos:
+    title: Project or Workspace path
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
+    env_key: BITRISE_PROJECT_PATH
+    type: selector
+    value_map:
+      Package.swift:
+        title: Scheme name
+        summary: An Xcode scheme defines a collection of targets to build, a configuration
+          to use when building, and a collection of tests to execute. Only shared
+          schemes are detected automatically but you can use any scheme as a target
+          on Bitrise. You can change the scheme at any time in your Env Vars.
+        env_key: BITRISE_SCHEME
+        type: selector
+        value_map:
+          CoolFeature-Package:
+            config: macos-spm-project-test-config
 configs:
   ios:
     ios-spm-project-test-config: |
@@ -1326,8 +1354,25 @@ configs:
               - test_repetition_mode: retry_on_failure
               - cache_level: none
           - deploy-to-bitrise-io@%s: {}
+  macos:
+    macos-spm-project-test-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: macos
+      workflows:
+        primary:
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - xcode-test-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+          - deploy-to-bitrise-io@%s: {}
 warnings:
   ios: []
+  macos: []
 warnings_with_recommendations:
   ios: []
+  macos: []
  `, sampleSPMProjectVersions...)

--- a/_tests/integration/mac_test.go
+++ b/_tests/integration/mac_test.go
@@ -18,6 +18,13 @@ func TestMacOS(t *testing.T) {
 			sampleAppsOSX1011ResultYML,
 			sampleAppsOSX1011Versions,
 		},
+		{
+			"sample-spm-mac-project",
+			"https://github.com/bitrise-io/sample-spm-project.git",
+			"",
+			sampleSPMMacProjectResultYML,
+			sampleSPMMacProjectVersions,
+		},
 	}
 
 	helper.Execute(t, testCases)
@@ -113,3 +120,107 @@ warnings:
 warnings_with_recommendations:
   macos: []
 `, sampleAppsOSX1011Versions...)
+
+var sampleSPMMacProjectVersions = []interface{}{
+	// iOS
+	models.FormatVersion,
+
+	// ios-spm-project-test-config
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.XcodeTestVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// macOS
+	models.FormatVersion,
+
+	// macos-spm-project-test-config
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.XcodeTestMacVersion,
+	steps.DeployToBitriseIoVersion,
+}
+var sampleSPMMacProjectResultYML = fmt.Sprintf(`options:
+  ios:
+    title: Project or Workspace path
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
+    env_key: BITRISE_PROJECT_PATH
+    type: selector
+    value_map:
+      Package.swift:
+        title: Scheme name
+        summary: An Xcode scheme defines a collection of targets to build, a configuration
+          to use when building, and a collection of tests to execute. Only shared
+          schemes are detected automatically but you can use any scheme as a target
+          on Bitrise. You can change the scheme at any time in your Env Vars.
+        env_key: BITRISE_SCHEME
+        type: selector
+        value_map:
+          CoolFeature-Package:
+            config: ios-spm-project-test-config
+  macos:
+    title: Project or Workspace path
+    summary: The location of your Xcode project, Xcode workspace or SPM project files
+      stored as an Environment Variable. In your Workflows, you can specify paths
+      relative to this path.
+    env_key: BITRISE_PROJECT_PATH
+    type: selector
+    value_map:
+      Package.swift:
+        title: Scheme name
+        summary: An Xcode scheme defines a collection of targets to build, a configuration
+          to use when building, and a collection of tests to execute. Only shared
+          schemes are detected automatically but you can use any scheme as a target
+          on Bitrise. You can change the scheme at any time in your Env Vars.
+        env_key: BITRISE_SCHEME
+        type: selector
+        value_map:
+          CoolFeature-Package:
+            config: macos-spm-project-test-config
+configs:
+  ios:
+    ios-spm-project-test-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: ios
+      workflows:
+        primary:
+          description: |
+            The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+
+            Next steps:
+            - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - xcode-test@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+              - test_repetition_mode: retry_on_failure
+              - cache_level: none
+          - deploy-to-bitrise-io@%s: {}
+  macos:
+    macos-spm-project-test-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: macos
+      workflows:
+        primary:
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - xcode-test-mac@%s:
+              inputs:
+              - project_path: $BITRISE_PROJECT_PATH
+              - scheme: $BITRISE_SCHEME
+          - deploy-to-bitrise-io@%s: {}
+warnings:
+  ios: []
+  macos: []
+warnings_with_recommendations:
+  ios: []
+  macos: []
+ `, sampleSPMMacProjectVersions...)

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -33,6 +33,13 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 		return false, err
 	}
 
+	if len(result.Projects) == 0 {
+		result, err = ios.ParseSPMProject(ios.XcodeProjectTypeMacOS, searchDir)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	scanner.detectResult = result
 	detected := len(result.Projects) > 0
 	return detected, err


### PR DESCRIPTION
This PR hooks up the Mac scanner with the same SPM logic the iOS scanner has. 

Both the iOS and Mac e2e tests had to be updated because the test SPM project I am using (https://github.com/bitrise-io/sample-spm-project.git) is a universal one supporting all of the platforms. So both the iOS and Mac scanner will detect it and will generate a config. 