### PR TITLE
[CI-1884] Rename private repo naming to ssh key specific

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -36,13 +36,12 @@ type ScanResultModel struct {
 	Icons                                []Icon                               `json:"-" yaml:"-"`
 }
 
-type RepoAccess int
+type SSHKeyActivation int
 
 const (
-	// RepoAccessUnknown should be used in generating default configs where the access is unknown
-	RepoAccessUnknown = iota
-	RepoAccessPublic
-	RepoAccessPrivate
+	SSHKeyActivationNone = iota
+	SSHKeyActivationMandatory
+	SSHKeyActivationConditional
 )
 
 func (result *ScanResultModel) AddErrorWithRecommendation(platform string, recommendation ErrorWithRecommendations) {

--- a/scanner/result.go
+++ b/scanner/result.go
@@ -16,8 +16,8 @@ import (
 )
 
 // GenerateScanResult runs the scanner, returns the results and if any platform was detected.
-func GenerateScanResult(searchDir string, isPrivateRepository bool) (models.ScanResultModel, bool) {
-	scanResult := Config(searchDir, isPrivateRepository)
+func GenerateScanResult(searchDir string, hasSSHKey bool) (models.ScanResultModel, bool) {
+	scanResult := Config(searchDir, hasSSHKey)
 
 	logUnknownTools(searchDir)
 

--- a/scanners/cordova/cordova.go
+++ b/scanners/cordova/cordova.go
@@ -281,10 +281,10 @@ func (*Scanner) DefaultOptions() models.OptionNode {
 	return *workDirOption
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: repoAccess,
+		SSHKeyActivation: sshKeyActivation,
 	})...)
 
 	workdirEnvList := []envmanModels.EnvironmentItemModel{}
@@ -309,7 +309,7 @@ func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseCon
 
 		// CD
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-			RepoAccess: repoAccess,
+			SSHKeyActivation: sshKeyActivation,
 		})...)
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
 
@@ -384,7 +384,7 @@ func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseCon
 func (*Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: models.RepoAccessUnknown,
+		SSHKeyActivation: models.SSHKeyActivationConditional,
 	})...)
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())

--- a/scanners/fastlane/fastlane.go
+++ b/scanners/fastlane/fastlane.go
@@ -190,11 +190,11 @@ func (*Scanner) DefaultOptions() models.OptionNode {
 	return *workDirOption
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
 	generateConfig := func(isIOS bool) (bitriseModels.BitriseDataModel, error) {
 		configBuilder := models.NewDefaultConfigBuilder()
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-			RepoAccess: repoAccess,
+			SSHKeyActivation: sshKeyActivation,
 		})...)
 
 		if isIOS {
@@ -246,7 +246,7 @@ func (*Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 
 	for _, p := range platforms {
 		configBuilder := models.NewDefaultConfigBuilder()
-		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{RepoAccess: models.RepoAccessUnknown})...)
+		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{SSHKeyActivation: models.SSHKeyActivationConditional})...)
 
 		if p == iosPlatform {
 			configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())

--- a/scanners/flutter/flutter.go
+++ b/scanners/flutter/flutter.go
@@ -189,11 +189,11 @@ func (scanner *Scanner) DefaultOptions() models.OptionNode {
 	return *flutterProjectLocationOption
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
 	configs := models.BitriseConfigMap{}
 
 	for _, proj := range scanner.projects {
-		config, err := generateConfig(repoAccess, proj)
+		config, err := generateConfig(sshKeyActivation, proj)
 		if err != nil {
 			return nil, err
 		}
@@ -210,7 +210,7 @@ func (scanner *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 	for i, proj := range defaultProjects {
 		proj.id = i
 
-		config, err := generateConfig(models.RepoAccessUnknown, proj)
+		config, err := generateConfig(models.SSHKeyActivationConditional, proj)
 		if err != nil {
 			return nil, err
 		}
@@ -243,11 +243,11 @@ func findProjectLocations(searchDir string) ([]string, error) {
 	return paths, nil
 }
 
-func generateConfig(repoAccess models.RepoAccess, proj project) (string, error) {
+func generateConfig(sshKeyActivation models.SSHKeyActivation, proj project) (string, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 
 	// Common steps to all workflows
-	prepareSteps := steps.DefaultPrepareStepList(steps.PrepareListParams{RepoAccess: repoAccess})
+	prepareSteps := steps.DefaultPrepareStepList(steps.PrepareListParams{SSHKeyActivation: sshKeyActivation})
 	flutterInstallStep := steps.FlutterInstallStepListItem(proj.flutterVersionToUse, false)
 	deploySteps := steps.DefaultDeployStepList()
 

--- a/scanners/ionic/ionic.go
+++ b/scanners/ionic/ionic.go
@@ -275,10 +275,10 @@ func (Scanner) DefaultOptions() models.OptionNode {
 	return *workDirOption
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: repoAccess,
+		SSHKeyActivation: sshKeyActivation,
 	})...)
 
 	workdirEnvList := []envmanModels.EnvironmentItemModel{}
@@ -374,7 +374,7 @@ func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseCon
 
 func (Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
-	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{RepoAccess: models.RepoAccessUnknown})...)
+	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{SSHKeyActivation: models.SSHKeyActivationConditional})...)
 
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.CertificateAndProfileInstallerStepListItem())
 

--- a/scanners/ios/ios.go
+++ b/scanners/ios/ios.go
@@ -69,8 +69,8 @@ func (scanner *Scanner) DefaultOptions() models.OptionNode {
 	return GenerateDefaultOptions(XcodeProjectTypeIOS)
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
-	return GenerateConfig(XcodeProjectTypeIOS, scanner.ConfigDescriptors, repoAccess)
+func (scanner *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
+	return GenerateConfig(XcodeProjectTypeIOS, scanner.ConfigDescriptors, sshKeyActivation)
 }
 
 // DefaultConfigs ...

--- a/scanners/ios/utility.go
+++ b/scanners/ios/utility.go
@@ -589,7 +589,7 @@ func GenerateDefaultOptions(projectType XcodeProjectType) models.OptionNode {
 
 func GenerateConfigBuilder(
 	projectType XcodeProjectType,
-	repoAccess models.RepoAccess,
+	sshKeyActivation models.SSHKeyActivation,
 	hasPodfile,
 	hasTest,
 	hasAppClip,
@@ -604,7 +604,7 @@ func GenerateConfigBuilder(
 	params := workflowSetupParams{
 		projectType:          projectType,
 		configBuilder:        configBuilder,
-		repoAccess:           repoAccess,
+		sshKeyActivation:     sshKeyActivation,
 		missingSharedSchemes: missingSharedSchemes,
 		hasTests:             hasTest,
 		hasAppClip:           hasAppClip,
@@ -638,12 +638,12 @@ func RemoveDuplicatedConfigDescriptors(configDescriptors []ConfigDescriptor, pro
 	return descriptors
 }
 
-func GenerateConfig(projectType XcodeProjectType, configDescriptors []ConfigDescriptor, repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func GenerateConfig(projectType XcodeProjectType, configDescriptors []ConfigDescriptor, sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
 	bitriseDataMap := models.BitriseConfigMap{}
 	for _, descriptor := range configDescriptors {
 		configBuilder := GenerateConfigBuilder(
 			projectType,
-			repoAccess,
+			sshKeyActivation,
 			descriptor.HasPodfile,
 			descriptor.HasTest,
 			descriptor.HasAppClip,
@@ -672,7 +672,7 @@ func GenerateConfig(projectType XcodeProjectType, configDescriptors []ConfigDesc
 func GenerateDefaultConfig(projectType XcodeProjectType) (models.BitriseConfigMap, error) {
 	configBuilder := GenerateConfigBuilder(
 		projectType,
-		models.RepoAccessUnknown,
+		models.SSHKeyActivationConditional,
 		true,
 		true,
 		false,

--- a/scanners/ios/workflow.go
+++ b/scanners/ios/workflow.go
@@ -42,7 +42,7 @@ const (
 type workflowSetupParams struct {
 	projectType          XcodeProjectType
 	configBuilder        *models.ConfigBuilderModel
-	repoAccess           models.RepoAccess
+	sshKeyActivation     models.SSHKeyActivation
 	missingSharedSchemes bool
 	hasTests             bool
 	hasAppClip           bool
@@ -167,7 +167,7 @@ func addArchiveStep(workflow models.WorkflowID, configBuilder *models.ConfigBuil
 
 func addSharedSetupSteps(workflow models.WorkflowID, params workflowSetupParams, includeCertificateAndProfileInstallStep, includeCache bool) {
 	params.configBuilder.AppendStepListItemsTo(workflow, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: params.repoAccess,
+		SSHKeyActivation: params.sshKeyActivation,
 	})...)
 
 	if includeCache {

--- a/scanners/macos/macos.go
+++ b/scanners/macos/macos.go
@@ -66,8 +66,8 @@ func (Scanner) DefaultOptions() models.OptionNode {
 	return ios.GenerateDefaultOptions(ios.XcodeProjectTypeMacOS)
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
-	return ios.GenerateConfig(ios.XcodeProjectTypeMacOS, scanner.configDescriptors, repoAccess)
+func (scanner *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
+	return ios.GenerateConfig(ios.XcodeProjectTypeMacOS, scanner.configDescriptors, sshKeyActivation)
 }
 
 func (Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {

--- a/scanners/reactnative/expo.go
+++ b/scanners/reactnative/expo.go
@@ -34,7 +34,7 @@ func (scanner *Scanner) expoOptions() models.OptionNode {
 }
 
 // expoConfigs implements ScannerInterface.Configs function for Expo based React Native projects.
-func (scanner *Scanner) expoConfigs(project project, repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) expoConfigs(project project, sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
 	configMap := models.BitriseConfigMap{}
 
 	if project.projectRelDir == "." {
@@ -52,7 +52,7 @@ func (scanner *Scanner) expoConfigs(project project, repoAccess models.RepoAcces
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryDescription)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: repoAccess,
+		SSHKeyActivation: sshKeyActivation,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, testSteps...)
@@ -67,7 +67,7 @@ func (scanner *Scanner) expoConfigs(project project, repoAccess models.RepoAcces
 
 	configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployDescription)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: repoAccess,
+		SSHKeyActivation: sshKeyActivation,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, testSteps...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.RunEASBuildStepListItem(project.projectRelDir, "$"+expoPlatformInputEnvKey))
@@ -111,7 +111,7 @@ func (scanner Scanner) expoDefaultConfigs() (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, expoPrimaryWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: models.RepoAccessUnknown,
+		SSHKeyActivation: models.SSHKeyActivationConditional,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, getTestSteps("$"+expoProjectDirInputEnvKey, true, true)...)
@@ -121,7 +121,7 @@ func (scanner Scanner) expoDefaultConfigs() (models.BitriseConfigMap, error) {
 	// deploy workflow
 	configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, expoDeployWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: models.RepoAccessUnknown,
+		SSHKeyActivation: models.SSHKeyActivationConditional,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, getTestSteps("$"+expoProjectDirInputEnvKey, true, true)...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.RunEASBuildStepListItem("$"+expoProjectDirInputEnvKey, "$"+expoPlatformInputEnvKey))

--- a/scanners/reactnative/plain.go
+++ b/scanners/reactnative/plain.go
@@ -175,7 +175,7 @@ func (scanner *Scanner) defaultOptions() models.OptionNode {
 	return *androidOptions
 }
 
-func (scanner *Scanner) configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
 	configMap := models.BitriseConfigMap{}
 
 	if len(scanner.configDescriptors) == 0 {
@@ -194,7 +194,7 @@ func (scanner *Scanner) configs(repoAccess models.RepoAccess) (models.BitriseCon
 
 		configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryDescription)
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-			RepoAccess: repoAccess,
+			SSHKeyActivation: sshKeyActivation,
 		})...)
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 		configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, testSteps...)
@@ -204,7 +204,7 @@ func (scanner *Scanner) configs(repoAccess models.RepoAccess) (models.BitriseCon
 		// cd
 		configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployWorkflowDescription)
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-			RepoAccess: repoAccess,
+			SSHKeyActivation: sshKeyActivation,
 		})...)
 		configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, testSteps...)
 
@@ -273,7 +273,7 @@ func (scanner *Scanner) defaultConfigs() (models.BitriseConfigMap, error) {
 	// primary
 	configBuilder.SetWorkflowDescriptionTo(models.PrimaryWorkflowID, primaryWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: models.RepoAccessUnknown,
+		SSHKeyActivation: models.SSHKeyActivationConditional,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.RestoreNPMCache())
 	// Assuming project uses yarn and has tests
@@ -284,7 +284,7 @@ func (scanner *Scanner) defaultConfigs() (models.BitriseConfigMap, error) {
 	// deploy
 	configBuilder.SetWorkflowDescriptionTo(models.DeployWorkflowID, deployWorkflowDescription)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: models.RepoAccessUnknown,
+		SSHKeyActivation: models.SSHKeyActivationConditional,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.DeployWorkflowID, getTestSteps("", true, true)...)
 

--- a/scanners/reactnative/reactnative.go
+++ b/scanners/reactnative/reactnative.go
@@ -252,12 +252,12 @@ func (scanner *Scanner) Options() (options models.OptionNode, allWarnings models
 	return
 }
 
-func (scanner *Scanner) Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error) {
+func (scanner *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
 	if scanner.isExpoBased {
-		return scanner.expoConfigs(scanner.projects[0], repoAccess)
+		return scanner.expoConfigs(scanner.projects[0], sshKeyActivation)
 	}
 
-	return scanner.configs(repoAccess)
+	return scanner.configs(sshKeyActivation)
 }
 
 // DefaultOptions implements ScannerInterface.DefaultOptions function.

--- a/scanners/scanners.go
+++ b/scanners/scanners.go
@@ -53,7 +53,7 @@ type ScannerInterface interface {
 	// Every config's key should be the last option one of the OptionNode branches.
 	// Returns:
 	// - platform BitriseConfigMap
-	Configs(repoAccess models.RepoAccess) (models.BitriseConfigMap, error)
+	Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error)
 
 	// Returns:
 	// - platform default BitriseConfigMap
@@ -97,7 +97,7 @@ const CustomConfigName = "other-config"
 func CustomConfig() (models.BitriseConfigMap, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultPrepareStepList(steps.PrepareListParams{
-		RepoAccess: models.RepoAccessUnknown,
+		SSHKeyActivation: models.SSHKeyActivationConditional,
 	})...)
 	configBuilder.AppendStepListItemsTo(models.PrimaryWorkflowID, steps.DefaultDeployStepList()...)
 

--- a/steps/steps.go
+++ b/steps/steps.go
@@ -10,7 +10,7 @@ import (
 
 // PrepareListParams describes the default prepare Step options.
 type PrepareListParams struct {
-	RepoAccess models.RepoAccess
+	SSHKeyActivation models.SSHKeyActivation
 }
 
 func stepIDComposite(ID, version string) string {
@@ -40,18 +40,18 @@ func stepListItem(stepIDComposite, title, runIf string, inputs ...envmanModels.E
 func DefaultPrepareStepList(params PrepareListParams) []bitriseModels.StepListItemModel {
 	stepList := []bitriseModels.StepListItemModel{}
 
-	switch params.RepoAccess {
-	case models.RepoAccessPublic:
+	switch params.SSHKeyActivation {
+	case models.SSHKeyActivationNone:
 		{
 			// No SSH key setup needed
 		}
-	case models.RepoAccessPrivate:
+	case models.SSHKeyActivationMandatory:
 		{
 			// This needs the `SSH_RSA_PRIVATE_KEY` env to be defined, which depends on the selected path in the website
 			// add-new-app flow.
 			stepList = append(stepList, ActivateSSHKeyStepListItem(""))
 		}
-	case models.RepoAccessUnknown:
+	case models.SSHKeyActivationConditional:
 		{
 			// Add the SSH key step just in case, but only run it if the required env var is available.
 			runCondition := `{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}`


### PR DESCRIPTION
<!--
  Thanks for contributing to the Project Scanner Core package!
  Please fill this template with the details of your change.
-->

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

We had a private repository related naming (`isPrivateRepository`, `models.RepoAccessPrivate`) in the project scanner which is not accurate anymore. This PR is to improve this and prevent confusion. 

In the past we thought about private repos as the ones which needs to be accessed through ssh. This is not accurate anymore because you can have private https based repos too. In the code we had this private repo specific names which in the end only affected the existence of the activate ssh key step. 

The main changes is that I renamed this:
```
type RepoAccess int

const (
	// RepoAccessUnknown should be used in generating default configs where the access is unknown
	RepoAccessUnknown = iota
	RepoAccessPublic
	RepoAccessPrivate
)
```
to
```
type SSHKeyActivation int

const (
	SSHKeyActivationNone = iota
	SSHKeyActivationMandatory
	SSHKeyActivationConditional
)
```
and had to drag it though all of the scanners.

I wanted to completely get rid of the private repo naming so checked how the `RepoAccess` enum is used and saw that it only affects if the generated workflow will have an activate ssh key step or not. So I thought I will rename this to something that reflects what it actually affects. 

This how the project scanner uses the init package:
https://github.com/bitrise-steplib/steps-project-scanner/blob/ea76c5bf2fece437440524e5e691e7a662b935c1/main.go#L200-L201

And this will be renamed to 
```
hasSSHKey := cfg.SSHRsaPrivateKey != ""
result, platformsDetected := scanner.GenerateScanResult(searchDir, hasSSHKey)
```
in a following PR once this is merged.