### PR TITLE
Update go-flutter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/beevik/etree v1.2.0
 	github.com/bitrise-io/bitrise v0.0.0-20230707121919-a5b9e2d27ea9
 	github.com/bitrise-io/envman v0.0.0-20230721122944-6b164ed0c2f8
-	github.com/bitrise-io/go-flutter v0.1.0
+	github.com/bitrise-io/go-flutter v0.1.1-0.20231026135119-63611c31d76e
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-utils v1.0.9
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/beevik/etree v1.2.0
 	github.com/bitrise-io/bitrise v0.0.0-20230707121919-a5b9e2d27ea9
 	github.com/bitrise-io/envman v0.0.0-20230721122944-6b164ed0c2f8
-	github.com/bitrise-io/go-flutter v0.1.1-0.20231026135119-63611c31d76e
+	github.com/bitrise-io/go-flutter v0.1.1
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-utils v1.0.9
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bitrise-io/bitrise v0.0.0-20230707121919-a5b9e2d27ea9 h1:WMaMm6qwwEoA
 github.com/bitrise-io/bitrise v0.0.0-20230707121919-a5b9e2d27ea9/go.mod h1:WcWeEnuP6x54mUVw9L9pGUmllo67aqtXGr+pBIWv+4A=
 github.com/bitrise-io/envman v0.0.0-20230721122944-6b164ed0c2f8 h1:tBhRcS1lxkFrPpnYHbeeQE3DzEVEbs8CMs2y2ppVPB0=
 github.com/bitrise-io/envman v0.0.0-20230721122944-6b164ed0c2f8/go.mod h1:eZDEXpkF4BguvTERmhij3Vwf7Y2qvnJBBW/61hQRip4=
-github.com/bitrise-io/go-flutter v0.1.1-0.20231026135119-63611c31d76e h1:7wMVZEr0RvfSlstGHZ73Dm+rCLz0Bsoji0ZkO5iXZHo=
-github.com/bitrise-io/go-flutter v0.1.1-0.20231026135119-63611c31d76e/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
+github.com/bitrise-io/go-flutter v0.1.1 h1:EKgwqiyeuyMf9V0Oad/MbMNrDA4wh2OZfIWZw5UF/Hs=
+github.com/bitrise-io/go-flutter v0.1.1/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10 h1:/2OyBFI7GjYKexBPcfTPvKFz8Ks7qYzkkz2SQ8aiJgc=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10/go.mod h1:pARutiL3kEuRLV3JvswidvfCj+9Y3qMZtji2BDqLFsA=
 github.com/bitrise-io/go-steputils v1.0.5 h1:OBH7CPXeqIWFWJw6BOUMQnUb8guspwKr2RhYBhM9tfc=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bitrise-io/bitrise v0.0.0-20230707121919-a5b9e2d27ea9 h1:WMaMm6qwwEoA
 github.com/bitrise-io/bitrise v0.0.0-20230707121919-a5b9e2d27ea9/go.mod h1:WcWeEnuP6x54mUVw9L9pGUmllo67aqtXGr+pBIWv+4A=
 github.com/bitrise-io/envman v0.0.0-20230721122944-6b164ed0c2f8 h1:tBhRcS1lxkFrPpnYHbeeQE3DzEVEbs8CMs2y2ppVPB0=
 github.com/bitrise-io/envman v0.0.0-20230721122944-6b164ed0c2f8/go.mod h1:eZDEXpkF4BguvTERmhij3Vwf7Y2qvnJBBW/61hQRip4=
-github.com/bitrise-io/go-flutter v0.1.0 h1:ZWtCB5xbOip4sZA09swbKupbTdUo1V6z/GO6RBm9a2Y=
-github.com/bitrise-io/go-flutter v0.1.0/go.mod h1:K7fIbZ7Ibk+lwu+2RT63ypiffIUMjLue1yr9xKxp8go=
+github.com/bitrise-io/go-flutter v0.1.1-0.20231026135119-63611c31d76e h1:7wMVZEr0RvfSlstGHZ73Dm+rCLz0Bsoji0ZkO5iXZHo=
+github.com/bitrise-io/go-flutter v0.1.1-0.20231026135119-63611c31d76e/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10 h1:/2OyBFI7GjYKexBPcfTPvKFz8Ks7qYzkkz2SQ8aiJgc=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10/go.mod h1:pARutiL3kEuRLV3JvswidvfCj+9Y3qMZtji2BDqLFsA=
 github.com/bitrise-io/go-steputils v1.0.5 h1:OBH7CPXeqIWFWJw6BOUMQnUb8guspwKr2RhYBhM9tfc=

--- a/scanners/flutter/flutter.go
+++ b/scanners/flutter/flutter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-io/bitrise-init/steps"
 	envmanModels "github.com/bitrise-io/envman/models"
 	"github.com/bitrise-io/go-flutter/flutterproject"
+	"github.com/bitrise-io/go-flutter/fluttersdk"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/v2/fileutil"
@@ -105,7 +106,7 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 
 	currentID := -1
 	for _, projectLocation := range projectLocations {
-		flutterProj, err := flutterproject.New(projectLocation, fileutil.NewFileManager(), pathutilv2.NewPathChecker())
+		flutterProj, err := flutterproject.New(projectLocation, fileutil.NewFileManager(), pathutilv2.NewPathChecker(), fluttersdk.NewSDKVersionFinder())
 		if err != nil {
 			log.TErrorf(err.Error())
 			continue
@@ -117,7 +118,10 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 		hasIosProject := flutterProj.IOSProjectPth() != ""
 		hasAndroidProject := flutterProj.AndroidProjectPth() != ""
 
-		flutterVersion, err := flutterProj.FlutterSDKVersionToUse()
+		// TODO: The second return value (flutterChannel) is omitted,
+		//  because the Flutter Installer step is not able to install a Flutter SDK version from a specific channel.
+		//  This is not a hugh issue, because just a few SDK version is available on multiple channels (like 2.2.2).
+		flutterVersion, _, err := flutterProj.FlutterSDKVersionToUse()
 		if err != nil {
 			log.Warnf(err.Error())
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/bitrise-io/bitrise/models
 # github.com/bitrise-io/envman v0.0.0-20230721122944-6b164ed0c2f8
 ## explicit; go 1.18
 github.com/bitrise-io/envman/models
-# github.com/bitrise-io/go-flutter v0.1.0
+# github.com/bitrise-io/go-flutter v0.1.1-0.20231026135119-63611c31d76e
 ## explicit; go 1.20
 github.com/bitrise-io/go-flutter/flutterproject
 github.com/bitrise-io/go-flutter/flutterproject/internal/sdk

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/bitrise-io/bitrise/models
 # github.com/bitrise-io/envman v0.0.0-20230721122944-6b164ed0c2f8
 ## explicit; go 1.18
 github.com/bitrise-io/envman/models
-# github.com/bitrise-io/go-flutter v0.1.1-0.20231026135119-63611c31d76e
+# github.com/bitrise-io/go-flutter v0.1.1
 ## explicit; go 1.20
 github.com/bitrise-io/go-flutter/flutterproject
 github.com/bitrise-io/go-flutter/flutterproject/internal/sdk


### PR DESCRIPTION
### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes the project scanner crashes for a Flutter project, which specifies the project’s Flutter SDK version using asdf, and the SDK release channel is also specified ( flutter 3.13.6-stable).

Resolves: https://bitrise.atlassian.net/browse/BIVS-2191

### Changes

- Pull latest go-flutter version
