### PR TITLE
Use asdf to manage Node.js version [CI-4741]

### DIFF
--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -513,21 +513,14 @@ var customConfigResultYML = fmt.Sprintf(`options:
     type: user_input
     value_map:
       "":
-        title: Node Version
-        summary: The version of Node.js used in the project. Leave it empty to use
-          the latest Node version
-        env_key: NODEJS_VERSION
-        type: user_input_optional
+        title: Package Manager
+        summary: The package manager used in the project
+        type: selector
         value_map:
-          "":
-            title: Package Manager
-            summary: The package manager used in the project
-            type: selector
-            value_map:
-              npm:
-                config: default-node-js-npm-config
-              yarn:
-                config: default-node-js-yarn-config
+          npm:
+            config: default-node-js-npm-config
+          yarn:
+            config: default-node-js-yarn-config
   react-native:
     title: Is this an [Expo](https://expo.dev)-based React Native project?
     summary: |-

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1198,8 +1198,8 @@ configs:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
           - script@%s:
+              title: Install Node.js
               inputs:
-              - title: Install Node.js
               - content: |
                   #!/usr/bin/env bash
                   set -euxo pipefail
@@ -1244,8 +1244,8 @@ configs:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
           - script@%s:
+              title: Install Node.js
               inputs:
-              - title: Install Node.js
               - content: |
                   #!/usr/bin/env bash
                   set -euxo pipefail

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/bitrise-io/bitrise-init/_tests/integration/helper"
 	"github.com/bitrise-io/bitrise-init/models"
 	"github.com/bitrise-io/bitrise-init/output"
 	"github.com/bitrise-io/bitrise-init/scanner"
 	"github.com/bitrise-io/bitrise-init/steps"
 	"github.com/bitrise-io/go-utils/fileutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestManualConfig(t *testing.T) {
@@ -251,7 +252,7 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.NvmVersion,
+	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.NpmVersion,
@@ -261,7 +262,7 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.NvmVersion,
+	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
@@ -1203,10 +1204,25 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - nvm@%s:
+          - script@%s:
               inputs:
-              - node_version: $NODEJS_VERSION
-              - working_dir: $NODEJS_PROJECT_DIR
+              - title: Install Node.js
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+                  # so it should work out-of-the-box even if the project uses another Node.js manager
+                  # See: https://github.com/asdf-vm/asdf-nodejs
+                  asdf install nodejs
+
+                  popd > /dev/null
           - restore-npm-cache@%s: {}
           - npm@%s:
               title: npm install
@@ -1234,10 +1250,25 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
-          - nvm@%s:
+          - script@%s:
               inputs:
-              - node_version: $NODEJS_VERSION
-              - working_dir: $NODEJS_PROJECT_DIR
+              - title: Install Node.js
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+                  # so it should work out-of-the-box even if the project uses another Node.js manager
+                  # See: https://github.com/asdf-vm/asdf-nodejs
+                  asdf install nodejs
+
+                  popd > /dev/null
           - restore-npm-cache@%s: {}
           - yarn@%s:
               title: yarn install

--- a/_tests/integration/nodejs_test.go
+++ b/_tests/integration/nodejs_test.go
@@ -123,8 +123,8 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - script@%s:
+              title: Install Node.js
               inputs:
-              - title: Install Node.js
               - content: |
                   #!/usr/bin/env bash
                   set -euxo pipefail
@@ -168,8 +168,8 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - script@%s:
+              title: Install Node.js
               inputs:
-              - title: Install Node.js
               - content: |
                   #!/usr/bin/env bash
                   set -euxo pipefail
@@ -210,8 +210,8 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - script@%s:
+              title: Install Node.js
               inputs:
-              - title: Install Node.js
               - content: |
                   #!/usr/bin/env bash
                   set -euxo pipefail
@@ -255,8 +255,8 @@ configs:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
           - script@%s:
+              title: Install Node.js
               inputs:
-              - title: Install Node.js
               - content: |
                   #!/usr/bin/env bash
                   set -euxo pipefail

--- a/_tests/integration/nodejs_test.go
+++ b/_tests/integration/nodejs_test.go
@@ -44,26 +44,6 @@ var multiPackageYmlVersions = []interface{}{
 	steps.GitCloneVersion,
 	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
-	steps.NpmVersion,
-	steps.NpmVersion,
-	steps.NpmVersion,
-	steps.CacheSaveNPMVersion,
-
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.CacheRestoreNPMVersion,
-	steps.YarnVersion,
-	steps.YarnVersion,
-	steps.YarnVersion,
-	steps.CacheSaveNPMVersion,
-
-	models.FormatVersion,
-	steps.ActivateSSHKeyVersion,
-	steps.GitCloneVersion,
-	steps.ScriptVersion,
-	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
@@ -88,139 +68,52 @@ var multiPackageYml = fmt.Sprintf(`options:
     type: selector
     value_map:
       .:
-        title: Node Version
-        summary: The version of Node.js used in the project. Leave it empty to use
-          the latest Node version
-        env_key: NODEJS_VERSION
-        type: user_input_optional
+        title: Package Manager
+        summary: The package manager used in the project
+        type: selector
         value_map:
-          "":
-            title: Package Manager
-            summary: The package manager used in the project
-            type: selector
-            value_map:
-              npm:
-                config: node-js-npm-root-build-lint-test-config
-              yarn:
-                config: node-js-yarn-root-build-lint-test-config
+          npm:
+            config: node-js-npm-root-build-lint-test-config
+          yarn:
+            config: node-js-yarn-root-build-lint-test-config
       other-projects/node-version:
-        title: Node Version
-        summary: The version of Node.js used in the project. Leave it empty to use
-          the latest Node version
-        env_key: NODEJS_VERSION
+        title: Package Manager
+        summary: The package manager used in the project
         type: selector
         value_map:
-          "22":
-            title: Package Manager
-            summary: The package manager used in the project
-            type: selector
-            value_map:
-              npm:
-                config: node-js-npm-build-lint-test-config
+          npm:
+            config: node-js-npm-build-lint-test-config
       other-projects/nvmrc:
-        title: Node Version
-        summary: The version of Node.js used in the project. Leave it empty to use
-          the latest Node version
-        env_key: NODEJS_VERSION
+        title: Package Manager
+        summary: The package manager used in the project
         type: selector
         value_map:
-          lts:
-            title: Package Manager
-            summary: The package manager used in the project
-            type: selector
-            value_map:
-              npm:
-                config: node-js-npm-nvm-build-lint-test-config
+          npm:
+            config: node-js-npm-build-lint-test-config
       other-projects/tool-versions:
-        title: Node Version
-        summary: The version of Node.js used in the project. Leave it empty to use
-          the latest Node version
-        env_key: NODEJS_VERSION
+        title: Package Manager
+        summary: The package manager used in the project
         type: selector
         value_map:
-          "20":
-            title: Package Manager
-            summary: The package manager used in the project
-            type: selector
-            value_map:
-              npm:
-                config: node-js-npm-build-lint-test-config
+          npm:
+            config: node-js-npm-build-lint-test-config
       other-projects/yarn:
-        title: Node Version
-        summary: The version of Node.js used in the project. Leave it empty to use
-          the latest Node version
-        env_key: NODEJS_VERSION
+        title: Package Manager
+        summary: The package manager used in the project
         type: selector
         value_map:
-          "20":
-            title: Package Manager
-            summary: The package manager used in the project
-            type: selector
-            value_map:
-              yarn:
-                config: node-js-yarn-build-lint-test-config
+          yarn:
+            config: node-js-yarn-build-lint-test-config
       other-projects/yarn-nvmrc:
-        title: Node Version
-        summary: The version of Node.js used in the project. Leave it empty to use
-          the latest Node version
-        env_key: NODEJS_VERSION
+        title: Package Manager
+        summary: The package manager used in the project
         type: selector
         value_map:
-          lts:
-            title: Package Manager
-            summary: The package manager used in the project
-            type: selector
-            value_map:
-              yarn:
-                config: node-js-yarn-nvm-build-lint-test-config
+          yarn:
+            config: node-js-yarn-build-lint-test-config
 configs:
   node-js:
     node-js-npm-build-lint-test-config: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: node-js
-      workflows:
-        run_tests:
-          steps:
-          - activate-ssh-key@%s: {}
-          - git-clone@%s: {}
-          - script@%s:
-              inputs:
-              - title: Install Node.js
-              - content: |
-                  #!/usr/bin/env bash
-                  set -euxo pipefail
-
-                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
-                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
-
-                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
-
-                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
-                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
-                  # so it should work out-of-the-box even if the project uses another Node.js manager
-                  # See: https://github.com/asdf-vm/asdf-nodejs
-                  asdf install nodejs
-
-                  popd > /dev/null
-          - restore-npm-cache@%s: {}
-          - npm@%s:
-              title: npm install
-              inputs:
-              - workdir: $NODEJS_PROJECT_DIR
-              - command: install
-          - npm@%s:
-              title: npm run lint
-              inputs:
-              - workdir: $NODEJS_PROJECT_DIR
-              - command: run lint
-          - npm@%s:
-              title: npm run test
-              inputs:
-              - workdir: $NODEJS_PROJECT_DIR
-              - command: run test
-          - save-npm-cache@%s: {}
-    node-js-npm-nvm-build-lint-test-config: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: node-js
@@ -308,51 +201,6 @@ configs:
               - command: run test
           - save-npm-cache@%s: {}
     node-js-yarn-build-lint-test-config: |
-      format_version: "%s"
-      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-      project_type: node-js
-      workflows:
-        run_tests:
-          steps:
-          - activate-ssh-key@%s: {}
-          - git-clone@%s: {}
-          - script@%s:
-              inputs:
-              - title: Install Node.js
-              - content: |
-                  #!/usr/bin/env bash
-                  set -euxo pipefail
-
-                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
-                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
-
-                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
-
-                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
-                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
-                  # so it should work out-of-the-box even if the project uses another Node.js manager
-                  # See: https://github.com/asdf-vm/asdf-nodejs
-                  asdf install nodejs
-
-                  popd > /dev/null
-          - restore-npm-cache@%s: {}
-          - yarn@%s:
-              title: yarn install
-              inputs:
-              - workdir: $NODEJS_PROJECT_DIR
-              - command: install
-          - yarn@%s:
-              title: yarn run lint
-              inputs:
-              - workdir: $NODEJS_PROJECT_DIR
-              - command: run lint
-          - yarn@%s:
-              title: yarn run test
-              inputs:
-              - workdir: $NODEJS_PROJECT_DIR
-              - command: run test
-          - save-npm-cache@%s: {}
-    node-js-yarn-nvm-build-lint-test-config: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: node-js

--- a/_tests/integration/nodejs_test.go
+++ b/_tests/integration/nodejs_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNodeJs(t *testing.T) {
-	var testCases = []helper.TestCase{
+	testCases := []helper.TestCase{
 		{"multi-package", "https://github.com/bitrise-io/nestjs-sample-01-cats-app", "multi-package", multiPackageYml, multiPackageYmlVersions},
 	}
 
@@ -22,7 +22,7 @@ var multiPackageYmlVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.NvmVersion,
+	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.NpmVersion,
@@ -32,7 +32,7 @@ var multiPackageYmlVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.NvmVersion,
+	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.NpmVersion,
@@ -42,7 +42,7 @@ var multiPackageYmlVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.NvmVersion,
+	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.NpmVersion,
 	steps.NpmVersion,
@@ -52,7 +52,7 @@ var multiPackageYmlVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.NvmVersion,
+	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
@@ -62,7 +62,7 @@ var multiPackageYmlVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
-	steps.NvmVersion,
+	steps.ScriptVersion,
 	steps.CacheRestoreNPMVersion,
 	steps.YarnVersion,
 	steps.YarnVersion,
@@ -184,10 +184,25 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - nvm@%s:
+          - script@%s:
               inputs:
-              - node_version: $NODEJS_VERSION
-              - working_dir: $NODEJS_PROJECT_DIR
+              - title: Install Node.js
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+                  # so it should work out-of-the-box even if the project uses another Node.js manager
+                  # See: https://github.com/asdf-vm/asdf-nodejs
+                  asdf install nodejs
+
+                  popd > /dev/null
           - restore-npm-cache@%s: {}
           - npm@%s:
               title: npm install
@@ -214,9 +229,25 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - nvm@%s:
+          - script@%s:
               inputs:
-              - working_dir: $NODEJS_PROJECT_DIR
+              - title: Install Node.js
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+                  # so it should work out-of-the-box even if the project uses another Node.js manager
+                  # See: https://github.com/asdf-vm/asdf-nodejs
+                  asdf install nodejs
+
+                  popd > /dev/null
           - restore-npm-cache@%s: {}
           - npm@%s:
               title: npm install
@@ -243,9 +274,25 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - nvm@%s:
+          - script@%s:
               inputs:
-              - node_version: $NODEJS_VERSION
+              - title: Install Node.js
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+                  # so it should work out-of-the-box even if the project uses another Node.js manager
+                  # See: https://github.com/asdf-vm/asdf-nodejs
+                  asdf install nodejs
+
+                  popd > /dev/null
           - restore-npm-cache@%s: {}
           - npm@%s:
               title: npm install
@@ -269,10 +316,25 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - nvm@%s:
+          - script@%s:
               inputs:
-              - node_version: $NODEJS_VERSION
-              - working_dir: $NODEJS_PROJECT_DIR
+              - title: Install Node.js
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+                  # so it should work out-of-the-box even if the project uses another Node.js manager
+                  # See: https://github.com/asdf-vm/asdf-nodejs
+                  asdf install nodejs
+
+                  popd > /dev/null
           - restore-npm-cache@%s: {}
           - yarn@%s:
               title: yarn install
@@ -299,9 +361,25 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - nvm@%s:
+          - script@%s:
               inputs:
-              - working_dir: $NODEJS_PROJECT_DIR
+              - title: Install Node.js
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+                  # so it should work out-of-the-box even if the project uses another Node.js manager
+                  # See: https://github.com/asdf-vm/asdf-nodejs
+                  asdf install nodejs
+
+                  popd > /dev/null
           - restore-npm-cache@%s: {}
           - yarn@%s:
               title: yarn install
@@ -328,9 +406,25 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
-          - nvm@%s:
+          - script@%s:
               inputs:
-              - node_version: $NODEJS_VERSION
+              - title: Install Node.js
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+                  envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+                  pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+                  # Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+                  # asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+                  # so it should work out-of-the-box even if the project uses another Node.js manager
+                  # See: https://github.com/asdf-vm/asdf-nodejs
+                  asdf install nodejs
+
+                  popd > /dev/null
           - restore-npm-cache@%s: {}
           - yarn@%s:
               title: yarn install

--- a/scanners/nodejs/nodejs.go
+++ b/scanners/nodejs/nodejs.go
@@ -18,10 +18,6 @@ const (
 	projectDirInputSummary = "The directory containing the package.json file"
 	projectDirInputEnvKey  = "NODEJS_PROJECT_DIR"
 
-	nodeVersionInputTitle   = "Node Version"
-	nodeVersionInputSummary = "The version of Node.js used in the project. Leave it empty to use the latest Node version"
-	nodeVersionInputEnvKey  = "NODEJS_VERSION"
-
 	packageManagerInputTitle   = "Package Manager"
 	packageManagerInputSummary = "The package manager used in the project"
 )
@@ -38,8 +34,6 @@ var pkgManagers = []packageManager{
 
 type project struct {
 	projectRelDir  string
-	nodeVersion    string
-	usesNvmrc      bool
 	packageManager string
 	scripts        []string
 	hasTest        bool
@@ -77,7 +71,6 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 		// determine workdir
 		pkgJsonDir := filepath.Dir(packageJsonPath)
 
-		node := checkNodeVersion(pkgJsonDir)
 		pkgMgr := checkPackageManager(pkgJsonDir)
 		results, err := checkPackageScripts(packageJsonPath)
 		if err != nil {
@@ -94,8 +87,6 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 		project := project{
 			projectRelDir:  projectRelDir,
 			packageManager: pkgMgr,
-			nodeVersion:    node.version,
-			usesNvmrc:      node.file == ".nvmrc",
 			scripts:        results.scripts,
 			hasTest:        results.hasTest,
 			hasLint:        results.hasLint,
@@ -131,7 +122,6 @@ func (scanner *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (model
 // DefaultOptions returns the default options for the scanner
 func (scanner *Scanner) DefaultOptions() models.OptionNode {
 	projectRootOption := models.NewOption(projectDirInputTitle, projectDirInputSummary, projectDirInputEnvKey, models.TypeUserInput)
-	nodeVersionOption := models.NewOption(nodeVersionInputTitle, nodeVersionInputSummary, nodeVersionInputEnvKey, models.TypeOptionalUserInput)
 	packageManagerOption := models.NewOption(packageManagerInputTitle, packageManagerInputSummary, "", models.TypeSelector)
 
 	for _, pkgMgr := range pkgManagers {
@@ -140,8 +130,7 @@ func (scanner *Scanner) DefaultOptions() models.OptionNode {
 		packageManagerOption.AddConfig(pkgMgr.name, configOption)
 	}
 
-	projectRootOption.AddOption(models.UserInputOptionDefaultValue, nodeVersionOption)
-	nodeVersionOption.AddOption(models.UserInputOptionDefaultValue, packageManagerOption)
+	projectRootOption.AddOption(models.UserInputOptionDefaultValue, packageManagerOption)
 
 	return *projectRootOption
 }

--- a/scanners/nodejs/utiltity.go
+++ b/scanners/nodejs/utiltity.go
@@ -108,7 +108,7 @@ func checkPackageScripts(packageJsonPath string) (checkScriptResult, error) {
 		return result, err
 	}
 
-	for name, _ := range packages.Scripts {
+	for name := range packages.Scripts {
 		log.TDebugf("- %s", name)
 		result.scripts = append(result.scripts, name)
 	}
@@ -295,7 +295,7 @@ func generateConfigBasedOn(descriptor configDescriptor, sshKey models.SSHKeyActi
 	prepareSteps := steps.DefaultPrepareStepList(steps.PrepareListParams{SSHKeyActivation: sshKey})
 	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, prepareSteps...)
 
-	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.NvmStepListItem(descriptor.nodeVersion, descriptor.workdir))
+	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem())
 	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreNPMCache())
 
 	switch descriptor.pkgManager {
@@ -313,7 +313,6 @@ func generateConfigBasedOn(descriptor configDescriptor, sshKey models.SSHKeyActi
 		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.NpmStepListItem("install", descriptor.workdir))
 		if descriptor.hasLint {
 			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.NpmStepListItem("run lint", descriptor.workdir))
-
 		}
 		if descriptor.hasTest {
 			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.NpmStepListItem("run test", descriptor.workdir))

--- a/scanners/nodejs/utiltity.go
+++ b/scanners/nodejs/utiltity.go
@@ -4,75 +4,18 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	"gopkg.in/yaml.v2"
 
 	"github.com/bitrise-io/bitrise-init/models"
 	"github.com/bitrise-io/bitrise-init/steps"
 	"github.com/bitrise-io/bitrise-init/utility"
-	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/log"
 )
-
-type nodeVersionResult struct {
-	version string
-	file    string
-}
 
 type checkScriptResult struct {
 	scripts                    []string
 	hasBuild, hasLint, hasTest bool
-}
-
-// Detection
-var nodeVersionFiles = []string{".nvmrc", ".node-version", ".tool-versions"}
-
-func checkNodeVersion(searchDir string) nodeVersionResult {
-	log.TPrintf("Checking Node version")
-
-	for _, fileName := range nodeVersionFiles {
-		versionFilePath := filepath.Join(searchDir, fileName)
-		hasVersionFile := utility.FileExists(versionFilePath)
-
-		if !hasVersionFile {
-			log.TPrintf("- %s - not found", fileName)
-			continue
-		}
-
-		log.TPrintf("- %s - found", fileName)
-		fileContent, err := fileutil.ReadStringFromFile(versionFilePath)
-		if err != nil {
-			log.TWarnf("Failed to read node version from %s", fileName)
-			continue
-		}
-
-		nodeVersion := strings.TrimSpace(fileContent)
-		if fileName == ".tool-versions" {
-			nodeVersion = getNodeVersionFromToolVersions(fileContent)
-		}
-
-		log.TPrintf("Node version: %s", nodeVersion)
-
-		return nodeVersionResult{
-			version: nodeVersion,
-			file:    fileName,
-		}
-	}
-
-	return nodeVersionResult{}
-}
-
-func getNodeVersionFromToolVersions(fileContent string) string {
-	lines := strings.Split(fileContent, "\n")
-	for _, line := range lines {
-		fields := strings.Fields(line)
-		if len(fields) == 2 && fields[0] == "nodejs" {
-			return fields[1]
-		}
-	}
-
-	return ""
 }
 
 func checkPackageManager(searchDir string) string {
@@ -139,34 +82,27 @@ func checkPackageScripts(packageJsonPath string) (checkScriptResult, error) {
 
 // Options & Configs
 type configDescriptor struct {
-	workdir     string
-	pkgManager  string
-	nodeVersion string
-	hasBuild    bool
-	hasLint     bool
-	hasTest     bool
-	isDefault   bool
+	workdir    string
+	pkgManager string
+	hasBuild   bool
+	hasLint    bool
+	hasTest    bool
+	isDefault  bool
 }
 
 func createConfigDescriptor(project project, isDefault bool) configDescriptor {
 	descriptor := configDescriptor{
-		workdir:     "$" + projectDirInputEnvKey,
-		nodeVersion: "$" + nodeVersionInputEnvKey,
-		pkgManager:  project.packageManager,
-		hasBuild:    project.hasBuild,
-		hasLint:     project.hasLint,
-		hasTest:     project.hasTest,
-		isDefault:   isDefault,
+		workdir:    "$" + projectDirInputEnvKey,
+		pkgManager: project.packageManager,
+		hasBuild:   project.hasBuild,
+		hasLint:    project.hasLint,
+		hasTest:    project.hasTest,
+		isDefault:  isDefault,
 	}
 
 	// package.json placed in the search dir, no need to change-dir
 	if project.projectRelDir == "." {
 		descriptor.workdir = ""
-	}
-
-	// Don't pin the Node version if the project uses .nvmrc
-	if project.usesNvmrc {
-		descriptor.nodeVersion = ""
 	}
 
 	return descriptor
@@ -175,9 +111,7 @@ func createConfigDescriptor(project project, isDefault bool) configDescriptor {
 func createDefaultConfigDescriptor(packageManager string) configDescriptor {
 	return createConfigDescriptor(project{
 		projectRelDir:  "$" + projectDirInputEnvKey,
-		nodeVersion:    "$" + nodeVersionInputEnvKey,
 		packageManager: packageManager,
-		usesNvmrc:      false,
 		hasBuild:       true,
 		hasLint:        true,
 		hasTest:        true,
@@ -197,10 +131,6 @@ func configName(params configDescriptor) string {
 
 	if params.workdir == "" {
 		name = name + "-root"
-	}
-
-	if params.nodeVersion == "" {
-		name = name + "-nvm"
 	}
 
 	if params.hasBuild {
@@ -235,13 +165,6 @@ func generateOptions(projects []project) (models.OptionNode, models.Warnings, mo
 func generateProjectOption(project project) models.OptionNode {
 	descriptor := createConfigDescriptor(project, false)
 
-	var nodeVersionOption *models.OptionNode
-	if project.nodeVersion != "" {
-		nodeVersionOption = models.NewOption(nodeVersionInputTitle, nodeVersionInputSummary, nodeVersionInputEnvKey, models.TypeSelector)
-	} else {
-		nodeVersionOption = models.NewOption(nodeVersionInputTitle, nodeVersionInputSummary, nodeVersionInputEnvKey, models.TypeOptionalUserInput)
-	}
-
 	packageManagerOption := models.NewOption(packageManagerInputTitle, packageManagerInputSummary, "", models.TypeSelector)
 	if project.packageManager != "" {
 		configOption := models.NewConfigOption(configName(descriptor), nil)
@@ -254,9 +177,7 @@ func generateProjectOption(project project) models.OptionNode {
 		}
 	}
 
-	nodeVersionOption.AddOption(project.nodeVersion, packageManagerOption)
-
-	return *nodeVersionOption
+	return *packageManagerOption
 }
 
 func generateConfigs(projects []project, sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {

--- a/steps/const.go
+++ b/steps/const.go
@@ -149,8 +149,8 @@ const (
 )
 
 const (
-	NvmID      = "nvm"
-	NvmVersion = "1"
+	ScriptID      = "script"
+	ScriptVersion = "1"
 )
 
 const (

--- a/steps/steps.go
+++ b/steps/steps.go
@@ -216,13 +216,13 @@ popd > /dev/null
 
 func ScriptStepListItem() bitriseModels.StepListItemModel {
 	var inputs []envmanModels.EnvironmentItemModel
+
 	inputs = append(inputs,
-		envmanModels.EnvironmentItemModel{"title": asdfInstallScriptStepTitle},
 		envmanModels.EnvironmentItemModel{"content": asdfInstallScriptStepContent},
 	)
 
 	stepIDComposite := stepIDComposite(ScriptID, ScriptVersion)
-	return stepListItem(stepIDComposite, "", "", inputs...)
+	return stepListItem(stepIDComposite, asdfInstallScriptStepTitle, "", inputs...)
 }
 
 func NpmStepListItem(command, workdir string) bitriseModels.StepListItemModel {

--- a/steps/steps.go
+++ b/steps/steps.go
@@ -194,16 +194,34 @@ func KarmaJasmineTestRunnerStepListItem(inputs ...envmanModels.EnvironmentItemMo
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 
-func NvmStepListItem(nodeVersion, workdir string) bitriseModels.StepListItemModel {
-	var inputs []envmanModels.EnvironmentItemModel
-	if nodeVersion != "" {
-		inputs = append(inputs, envmanModels.EnvironmentItemModel{"node_version": nodeVersion})
-	}
-	if workdir != "" {
-		inputs = append(inputs, envmanModels.EnvironmentItemModel{"working_dir": workdir})
-	}
+const (
+	asdfInstallScriptStepTitle   = "Install Node.js"
+	asdfInstallScriptStepContent = `#!/usr/bin/env bash
+set -euxo pipefail
 
-	stepIDComposite := stepIDComposite(NvmID, NvmVersion)
+export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+envman add --key ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY --value latest_installed
+
+pushd "${NODEJS_PROJECT_DIR:-.}" > /dev/null
+
+# Bitrise stacks come with asdf pre-installed to help auto-switch between various software versions
+# asdf looks for the Node.js version in these files: .tool-versions, .nvmrc, .node-version
+# so it should work out-of-the-box even if the project uses another Node.js manager
+# See: https://github.com/asdf-vm/asdf-nodejs
+asdf install nodejs
+
+popd > /dev/null
+`
+)
+
+func ScriptStepListItem() bitriseModels.StepListItemModel {
+	var inputs []envmanModels.EnvironmentItemModel
+	inputs = append(inputs,
+		envmanModels.EnvironmentItemModel{"title": asdfInstallScriptStepTitle},
+		envmanModels.EnvironmentItemModel{"content": asdfInstallScriptStepContent},
+	)
+
+	stepIDComposite := stepIDComposite(ScriptID, ScriptVersion)
 	return stepListItem(stepIDComposite, "", "", inputs...)
 }
 


### PR DESCRIPTION
[CI-4741]

![image](https://github.com/user-attachments/assets/99602dd9-4928-4c68-a841-4820bc8e4824)


<!--
  Thanks for contributing to the Project Scanner Core package!
  Please fill this template with the details of your change.
-->

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Bitrise stacks come with asdf pre-installed and it's the recommended tool for managing Node.js. (Stacks also have some Node.js versions available managed by asdf.) Let's use asdf in the default workflows for Node.js projects.

Please note, that we don't have an asdf step, so we used a script step for now. The environment doesn't have the `ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY` env var set, so we're setting it for now. (I'm reaching out to environment folks to discuss making this a default so we can remove it later.)

This PR also remove the complexity that comes with identifying and setting a Node.js version ourselves. If the project uses a standard way to pin a Node.js version (setting it in a known config file), then asdf will pick it up out-of-the-box. If the project doesn't pin a Node.js version, it will use the system default. We don't ship a custom solution for the user to set a Node.js version (e.g. via env var), we expect them to use a standard tool for this.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->


[CI-4741]: https://bitrise.atlassian.net/browse/CI-4741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ