### PR TITLE
Fix RN scanner's nil pointer dereference

### DIFF
--- a/scanners/reactnative/reactnative.go
+++ b/scanners/reactnative/reactnative.go
@@ -146,7 +146,9 @@ func getNativeProjects(packageJSONPth, relPackageJSONDir string) (ios.DetectResu
 	}
 	iosProjects.Projects = newIosProjects
 
-	androidProject.RootDirEntry.RelPath = filepath.Join(relPackageJSONDir, androidProject.RootDirEntry.RelPath)
+	if androidProject != nil {
+		androidProject.RootDirEntry.RelPath = filepath.Join(relPackageJSONDir, androidProject.RootDirEntry.RelPath)
+	}
 
 	return iosProjects, androidProject
 }


### PR DESCRIPTION
### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes a nil pointer dereference in the React Native project scanner.
