### PR TITLE
Fix kmp configs

### DIFF
--- a/_tests/integration/kmp_test.go
+++ b/_tests/integration/kmp_test.go
@@ -103,6 +103,7 @@ configs:
           steps:
           - activate-ssh-key@%s: {}
           - git-clone@%s: {}
+          - restore-gradle-cache@%s: {}
           - activate-build-cache-for-gradle@%s: {}
           - xcode-archive@%s:
               inputs:
@@ -111,6 +112,7 @@ configs:
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - configuration: Release
               - automatic_code_signing: api-key
+          - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
         run_tests:
           steps:
@@ -143,8 +145,10 @@ var kmpTaskmanResultVersions = []interface{}{
 	// ios_build
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreGradleVersion,
 	steps.ActivateBuildCacheForGradleVersion,
 	steps.XcodeArchiveVersion,
+	steps.CacheSaveGradleVersion,
 	steps.DeployToBitriseIoVersion,
 	// run_tests
 	steps.ActivateSSHKeyVersion,

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/bitrise-io/bitrise-init/_tests/integration/helper"
 	"github.com/bitrise-io/bitrise-init/models"
 	"github.com/bitrise-io/bitrise-init/output"
 	"github.com/bitrise-io/bitrise-init/scanner"
 	"github.com/bitrise-io/bitrise-init/steps"
 	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManualConfig(t *testing.T) {

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -279,8 +279,10 @@ var customConfigVersions = []interface{}{
 	steps.DeployToBitriseIoVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreGradleVersion,
 	steps.ActivateBuildCacheForGradleVersion,
 	steps.XcodeArchiveVersion,
+	steps.CacheSaveGradleVersion,
 	steps.DeployToBitriseIoVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -293,8 +295,10 @@ var customConfigVersions = []interface{}{
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
+	steps.CacheRestoreGradleVersion,
 	steps.ActivateBuildCacheForGradleVersion,
 	steps.XcodeArchiveVersion,
+	steps.CacheSaveGradleVersion,
 	steps.DeployToBitriseIoVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -1459,6 +1463,7 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
+          - restore-gradle-cache@%s: {}
           - activate-build-cache-for-gradle@%s: {}
           - xcode-archive@%s:
               inputs:
@@ -1467,6 +1472,7 @@ configs:
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - configuration: Release
               - automatic_code_signing: api-key
+          - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
         run_tests:
           steps:
@@ -1490,6 +1496,7 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
+          - restore-gradle-cache@%s: {}
           - activate-build-cache-for-gradle@%s: {}
           - xcode-archive@%s:
               inputs:
@@ -1498,6 +1505,7 @@ configs:
               - distribution_method: $BITRISE_DISTRIBUTION_METHOD
               - configuration: Release
               - automatic_code_signing: api-key
+          - save-gradle-cache@%s: {}
           - deploy-to-bitrise-io@%s: {}
         run_tests:
           steps:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1441,6 +1441,11 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: kotlin-multiplatform
+      pipelines:
+        build:
+          workflows:
+            android_build: {}
+            ios_build: {}
       workflows:
         android_build:
           steps:

--- a/scanners/kmp/kmp.go
+++ b/scanners/kmp/kmp.go
@@ -331,6 +331,7 @@ func (s *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.Bitr
 				envmanModels.EnvironmentItemModel{ios.CarthageCommandInputKey: s.kmpProject.IOSAppDetectResult.Projects[0].CarthageCommand},
 			))
 		}
+		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.RestoreGradleCache())
 		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.ActivateBuildCacheForGradle())
 
 		// Build step
@@ -352,6 +353,7 @@ func (s *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.Bitr
 		if s.kmpProject.IOSAppDetectResult.Projects[0].CarthageCommand != "" {
 			configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.SaveCarthageCache())
 		}
+		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.SaveGradleCache())
 
 		// Deploy step
 		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.DefaultDeployStepList()...)
@@ -516,6 +518,7 @@ func (s *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 		})...)
 
 		// Cache setup step
+		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.RestoreGradleCache())
 		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.ActivateBuildCacheForGradle())
 
 		// Build step
@@ -526,6 +529,9 @@ func (s *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 			envmanModels.EnvironmentItemModel{ios.ConfigurationInputKey: "Release"},
 			envmanModels.EnvironmentItemModel{ios.AutomaticCodeSigningInputKey: ios.AutomaticCodeSigningInputAPIKeyValue},
 		))
+
+		// Cache teardown steps
+		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.SaveGradleCache())
 
 		// Deploy step
 		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.DefaultDeployStepList()...)
@@ -603,6 +609,7 @@ func (s *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 		})...)
 
 		// Cache setup step
+		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.RestoreGradleCache())
 		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.ActivateBuildCacheForGradle())
 
 		// Build step
@@ -613,6 +620,9 @@ func (s *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 			envmanModels.EnvironmentItemModel{ios.ConfigurationInputKey: "Release"},
 			envmanModels.EnvironmentItemModel{ios.AutomaticCodeSigningInputKey: ios.AutomaticCodeSigningInputAPIKeyValue},
 		))
+
+		// Cache teardown steps
+		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.SaveGradleCache())
 
 		// Deploy step
 		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.DefaultDeployStepList()...)

--- a/scanners/kmp/kmp.go
+++ b/scanners/kmp/kmp.go
@@ -627,6 +627,11 @@ func (s *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
 		// Deploy step
 		configBuilder.AppendStepListItemsTo(iosBuildWorkflowID, steps.DefaultDeployStepList()...)
 
+		//
+		// iOS and Android build pipeline
+		configBuilder.SetGraphPipelineWorkflowTo(buildPipelineID, androidBuildWorkflowID, bitriseModels.GraphPipelineWorkflowModel{})
+		configBuilder.SetGraphPipelineWorkflowTo(buildPipelineID, iosBuildWorkflowID, bitriseModels.GraphPipelineWorkflowModel{})
+
 		config, err := configBuilder.Generate(projectType)
 		if err != nil {
 			return models.BitriseConfigMap{}, err


### PR DESCRIPTION
### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes the Kotlin Multiplatform generated configs:
- Add Gradle cache steps to the `ios_build` workflows
- Add `build` Pipeline to the manual config, when both iOS and Android app target presents
